### PR TITLE
fix: 카카오 로그인 시 사용자 정보 DB 저장 연동

### DIFF
--- a/src/main/java/com/ikongserver/auth/service/AuthService.java
+++ b/src/main/java/com/ikongserver/auth/service/AuthService.java
@@ -53,7 +53,8 @@ public class AuthService {
 
     @Transactional
     public LoginResponse kakaoLogin(KakaoLoginRequest request) {
-        String socialId = kakaoAuthService.getKakaoSocialId(request.getKakaoAccessToken());
+        KakaoAuthService.KakaoUserInfo kakaoUser = kakaoAuthService.getKakaoUserInfo(request.getKakaoAccessToken());
+        String socialId = kakaoUser.getSocialId();
         String userType = request.getUserType();
 
         boolean isNewUser = false;
@@ -66,7 +67,8 @@ public class AuthService {
                         isNew[0] = true;
                         return guardianRepository.save(Guardian.builder()
                                 .socialId(socialId)
-                                .name("보호자")
+                                .name(kakaoUser.getName() != null ? kakaoUser.getName() : "보호자")
+                                .phone(kakaoUser.getPhone())
                                 .build());
                     });
             id = String.valueOf(guardian.getId());
@@ -78,9 +80,15 @@ public class AuthService {
                         isNew[0] = true;
                         return usersRepository.save(Users.builder()
                                 .socialId(socialId)
-                                .name("사용자")
+                                .name(kakaoUser.getName() != null ? kakaoUser.getName() : "사용자")
+                                .phone(kakaoUser.getPhone())
+                                .birthDate(kakaoUser.getBirthDate())
                                 .build());
                     });
+            // 기존 유저도 카카오 정보 업데이트
+            if (!isNew[0]) {
+                user.updateFromKakao(kakaoUser.getName(), kakaoUser.getPhone(), kakaoUser.getBirthDate());
+            }
             id = String.valueOf(user.getId());
             isNewUser = isNew[0];
         }

--- a/src/main/java/com/ikongserver/auth/service/KakaoAuthService.java
+++ b/src/main/java/com/ikongserver/auth/service/KakaoAuthService.java
@@ -1,6 +1,8 @@
 package com.ikongserver.auth.service;
 
+import java.time.LocalDate;
 import java.util.Map;
+import lombok.Getter;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
@@ -9,7 +11,22 @@ public class KakaoAuthService {
 
     private static final String KAKAO_USER_INFO_URL = "https://kapi.kakao.com/v2/user/me";
 
-    public String getKakaoSocialId(String kakaoAccessToken) {
+    @Getter
+    public static class KakaoUserInfo {
+        private final String socialId;
+        private final String name;
+        private final String phone;
+        private final LocalDate birthDate;
+
+        public KakaoUserInfo(String socialId, String name, String phone, LocalDate birthDate) {
+            this.socialId = socialId;
+            this.name = name;
+            this.phone = phone;
+            this.birthDate = birthDate;
+        }
+    }
+
+    public KakaoUserInfo getKakaoUserInfo(String kakaoAccessToken) {
         RestClient restClient = RestClient.create();
 
         Map<?, ?> response = restClient.get()
@@ -22,6 +39,51 @@ public class KakaoAuthService {
             throw new RuntimeException("카카오 사용자 정보를 가져올 수 없습니다.");
         }
 
-        return String.valueOf(response.get("id"));
+        String socialId = String.valueOf(response.get("id"));
+
+        Map<?, ?> account = (Map<?, ?>) response.get("kakao_account");
+
+        String name = null;
+        String phone = null;
+        LocalDate birthDate = null;
+
+        if (account != null) {
+            // 이름
+            if (account.get("name") != null) {
+                name = String.valueOf(account.get("name"));
+            }
+
+            // 전화번호: "+82 10-1234-5678" → "010-1234-5678"
+            if (account.get("phone_number") != null) {
+                phone = convertPhone(String.valueOf(account.get("phone_number")));
+            }
+
+            // 생년: "1990" → LocalDate 1990-01-01
+            if (account.get("birthyear") != null) {
+                try {
+                    int year = Integer.parseInt(String.valueOf(account.get("birthyear")));
+                    birthDate = LocalDate.of(year, 1, 1);
+                } catch (NumberFormatException ignored) {}
+            }
+        }
+
+        return new KakaoUserInfo(socialId, name, phone, birthDate);
+    }
+
+    // 기존 메서드 유지 (하위 호환)
+    public String getKakaoSocialId(String kakaoAccessToken) {
+        return getKakaoUserInfo(kakaoAccessToken).getSocialId();
+    }
+
+    private String convertPhone(String kakaoPhone) {
+        // "+82 10-1234-5678" or "+82 1012345678" → "010-1234-5678"
+        String digits = kakaoPhone.replaceAll("[^0-9]", "");
+        if (digits.startsWith("82")) {
+            digits = "0" + digits.substring(2);
+        }
+        if (digits.length() == 11) {
+            return digits.substring(0, 3) + "-" + digits.substring(3, 7) + "-" + digits.substring(7);
+        }
+        return digits;
     }
 }

--- a/src/main/java/com/ikongserver/entity/Users.java
+++ b/src/main/java/com/ikongserver/entity/Users.java
@@ -54,6 +54,12 @@ public class Users {
         this.birthDate = birthDate;
     }
 
+    public void updateFromKakao(String name, String phone, LocalDate birthDate) {
+        if (name != null) this.name = name;
+        if (phone != null) this.phone = phone;
+        if (birthDate != null) this.birthDate = birthDate;
+    }
+
     @Builder
     public Users(String email, String password, String name, String phone, LocalDate birthDate, String socialId) {
         this.email = email;


### PR DESCRIPTION
## 변경 이유
카카오 로그인 성공 후 OAuth로 수신한 사용자 정보(이름, 전화번호, 생년월일)가
DB에 저장되지 않고 socialId만 저장되는 문제 수정

## 변경 사항

### KakaoAuthService
- 기존: socialId만 반환
- 변경: 카카오 API `/v2/user/me` 응답에서 name, phone_number, birthyear 파싱
- 전화번호 포맷 변환 추가 (`+82 10-xxxx-xxxx` → `010-xxxx-xxxx`)

### AuthService
- 신규 유저: 카카오 정보(name, phone, birthDate)로 저장
- 기존 유저: 로그인 시 카카오 최신 정보로 업데이트

### Users Entity
- `updateFromKakao()` 메서드 추가 (name, phone, birthDate 업데이트)

## 비고
- gender는 users 테이블에 컬럼 없어 저장 제외
- birthyear만 수신하므로 birth_date는 `YYYY-01-01`로 저장
