### PR TITLE
feat: 보호자 초대 API 추가 및 알림 피보호자 조회 지원

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = 'iKong-server'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of(26)
     }
 }
 

--- a/src/main/java/com/ikongserver/controller/GuardianController.java
+++ b/src/main/java/com/ikongserver/controller/GuardianController.java
@@ -40,6 +40,15 @@ public class GuardianController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
+    @PostMapping("/invite")
+    public ResponseEntity<ApiResponse<GuardianDto.ResponseInvite>> inviteGuardian(
+        @RequestParam Long userId, // TODO: JWT 인증 후 SecurityContext에서 userId 추출로 변경
+        @RequestBody GuardianDto.RequestInvite request
+    ) {
+        GuardianDto.ResponseInvite response = guardianService.inviteGuardian(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
+    }
+
     @DeleteMapping("/{guardianId}")
     public ResponseEntity<ApiResponse<Void>> deleteGuardian(
         @RequestParam Long userId, // TODO: JWT 인증 후 SecurityContext에서 userId 추출로 변경

--- a/src/main/java/com/ikongserver/controller/NotificationController.java
+++ b/src/main/java/com/ikongserver/controller/NotificationController.java
@@ -37,15 +37,18 @@ public class NotificationController {
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "20") int size) {
 
+        Long id = Long.parseLong(userDetails.getUsername());
+
         boolean isGuardian = userDetails.getAuthorities().stream()
                 .anyMatch(a -> a.getAuthority().equals("ROLE_GUARDIAN"));
 
-        if (!isGuardian) {
-            return ResponseEntity.status(403).build();
+        if (isGuardian) {
+            // 보호자: guardianId 기준으로 알림 조회
+            return ResponseEntity.ok(notificationService.getNotifications(id, status, page, size));
+        } else {
+            // 피보호자: userId 기준으로 연결된 응급 이벤트의 알림 조회
+            return ResponseEntity.ok(notificationService.getNotificationsByUserId(id, status, page, size));
         }
-
-        Long guardianId = Long.parseLong(userDetails.getUsername());
-        return ResponseEntity.ok(notificationService.getNotifications(guardianId, status, page, size));
     }
 
     @PatchMapping("/{notificationId}/read")

--- a/src/main/java/com/ikongserver/dto/GuardianDto.java
+++ b/src/main/java/com/ikongserver/dto/GuardianDto.java
@@ -1,5 +1,7 @@
 package com.ikongserver.dto;
 
+import java.time.LocalDateTime;
+
 public class GuardianDto {
 
     // 등록된 보호자 (피보호자 화면)
@@ -14,5 +16,14 @@ public class GuardianDto {
     // 보호자 등록 응답
     public record ResponseRegister(Long guardianId, String name, String phone, String relation,
                                    boolean isPrimary, boolean isActive) {
+    }
+
+    // 보호자 초대 요청
+    public record RequestInvite(String name, String phone, String relation, boolean isPrimary) {
+    }
+
+    // 보호자 초대 응답
+    public record ResponseInvite(Long invitationId, String name, String phone, String relation,
+                                 boolean isPrimary, String status, LocalDateTime createdAt) {
     }
 }

--- a/src/main/java/com/ikongserver/entity/GuardianInvitation.java
+++ b/src/main/java/com/ikongserver/entity/GuardianInvitation.java
@@ -1,0 +1,64 @@
+package com.ikongserver.entity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "guardian_invitation")
+public class GuardianInvitation {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private Users user;
+
+    @Column(nullable = false)
+    private String phone;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String relation;
+
+    private Boolean isPrimary = false;
+
+    @Column(nullable = false)
+    private String status = "PENDING";
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    public void accept() {
+        this.status = "ACCEPTED";
+    }
+
+    @Builder
+    public GuardianInvitation(Users user, String phone, String name, String relation, Boolean isPrimary) {
+        this.user = user;
+        this.phone = phone;
+        this.name = name;
+        this.relation = relation;
+        this.isPrimary = isPrimary != null ? isPrimary : false;
+        this.status = "PENDING";
+    }
+}

--- a/src/main/java/com/ikongserver/repository/GuardianInvitationRepository.java
+++ b/src/main/java/com/ikongserver/repository/GuardianInvitationRepository.java
@@ -1,0 +1,10 @@
+package com.ikongserver.repository;
+
+import com.ikongserver.entity.GuardianInvitation;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GuardianInvitationRepository extends JpaRepository<GuardianInvitation, Long> {
+
+    List<GuardianInvitation> findByPhoneAndStatus(String phone, String status);
+}

--- a/src/main/java/com/ikongserver/repository/NotificationRepository.java
+++ b/src/main/java/com/ikongserver/repository/NotificationRepository.java
@@ -4,8 +4,19 @@ import com.ikongserver.entity.Notification;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    // 보호자 기준 조회
     Page<Notification> findByGuardianId(Long guardianId, Pageable pageable);
     Page<Notification> findByGuardianIdAndStatus(Long guardianId, String status, Pageable pageable);
+
+    // 피보호자(userId) 기준 조회
+    @Query("SELECT n FROM Notification n WHERE n.emergencyEvent.user.id = :userId")
+    Page<Notification> findByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    @Query("SELECT n FROM Notification n WHERE n.emergencyEvent.user.id = :userId AND n.status = :status")
+    Page<Notification> findByUserIdAndStatus(@Param("userId") Long userId, @Param("status") String status, Pageable pageable);
 }

--- a/src/main/java/com/ikongserver/repository/UserGuardianMapRepository.java
+++ b/src/main/java/com/ikongserver/repository/UserGuardianMapRepository.java
@@ -1,5 +1,6 @@
 package com.ikongserver.repository;
 
+import com.ikongserver.entity.Guardian;
 import com.ikongserver.entity.UserGuardianMap;
 import com.ikongserver.entity.Users;
 import java.util.List;
@@ -10,4 +11,6 @@ public interface UserGuardianMapRepository extends JpaRepository<UserGuardianMap
     List<UserGuardianMap> findByUser(Users user);
 
     long countByUserAndIsActive(Users user, String isActive);
+
+    boolean existsByUserAndGuardian(Users user, Guardian guardian);
 }

--- a/src/main/java/com/ikongserver/service/AuthService.java
+++ b/src/main/java/com/ikongserver/service/AuthService.java
@@ -8,14 +8,19 @@ import com.ikongserver.dto.AuthDto.RefreshResponse;
 import com.ikongserver.dto.AuthDto.SignupRequest;
 import com.ikongserver.dto.AuthDto.SignupResponse;
 import com.ikongserver.entity.Guardian;
+import com.ikongserver.entity.GuardianInvitation;
 import com.ikongserver.entity.LogoutToken;
+import com.ikongserver.entity.UserGuardianMap;
 import com.ikongserver.entity.Users;
 import com.ikongserver.jwt.JwtUtil;
+import com.ikongserver.repository.GuardianInvitationRepository;
 import com.ikongserver.repository.GuardianRepository;
 import com.ikongserver.repository.LogoutTokenRepository;
+import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
 import io.jsonwebtoken.Claims;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -24,9 +29,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthService {
 
+    private static final int MAX_GUARDIAN_COUNT = 5;
+
     private final KakaoAuthService kakaoAuthService;
     private final UsersRepository usersRepository;
     private final GuardianRepository guardianRepository;
+    private final GuardianInvitationRepository guardianInvitationRepository;
+    private final UserGuardianMapRepository userGuardianMapRepository;
     private final LogoutTokenRepository logoutTokenRepository;
     private final JwtUtil jwtUtil;
 
@@ -67,6 +76,33 @@ public class AuthService {
                                 .phone(kakaoUser.phone())
                                 .build());
                     });
+
+            // 전화번호로 PENDING 초대 확인 및 자동 수락 (신규/기존 보호자 모두)
+            if (kakaoUser.phone() != null) {
+                List<GuardianInvitation> pendingInvitations =
+                        guardianInvitationRepository.findByPhoneAndStatus(kakaoUser.phone(), "PENDING");
+
+                for (GuardianInvitation invitation : pendingInvitations) {
+                    Users invitingUser = invitation.getUser();
+                    boolean alreadyMapped = userGuardianMapRepository
+                            .existsByUserAndGuardian(invitingUser, guardian);
+                    if (!alreadyMapped) {
+                        long activeCount = userGuardianMapRepository
+                                .countByUserAndIsActive(invitingUser, "Y");
+                        if (activeCount < MAX_GUARDIAN_COUNT) {
+                            userGuardianMapRepository.save(UserGuardianMap.builder()
+                                    .user(invitingUser)
+                                    .guardian(guardian)
+                                    .relation(invitation.getRelation())
+                                    .isPrimary(invitation.getIsPrimary() ? "Y" : "N")
+                                    .isActive("Y")
+                                    .build());
+                        }
+                    }
+                    invitation.accept();
+                }
+            }
+
             id = String.valueOf(guardian.getId());
             isNewUser = isNew[0];
         } else {

--- a/src/main/java/com/ikongserver/service/GuardianService.java
+++ b/src/main/java/com/ikongserver/service/GuardianService.java
@@ -2,8 +2,10 @@ package com.ikongserver.service;
 
 import com.ikongserver.dto.GuardianDto;
 import com.ikongserver.entity.Guardian;
+import com.ikongserver.entity.GuardianInvitation;
 import com.ikongserver.entity.UserGuardianMap;
 import com.ikongserver.entity.Users;
+import com.ikongserver.repository.GuardianInvitationRepository;
 import com.ikongserver.repository.GuardianRepository;
 import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
@@ -20,6 +22,7 @@ public class GuardianService {
     private static final int MAX_GUARDIAN_COUNT = 5;
 
     private final GuardianRepository guardianRepository;
+    private final GuardianInvitationRepository guardianInvitationRepository;
     private final UserGuardianMapRepository userGuardianMapRepository;
     private final UsersRepository usersRepository;
 
@@ -75,6 +78,31 @@ public class GuardianService {
                 mapping.getRelation()
             ))
             .toList();
+    }
+
+    @Transactional
+    public GuardianDto.ResponseInvite inviteGuardian(Long userId, GuardianDto.RequestInvite request) {
+        Users user = usersRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        GuardianInvitation invitation = GuardianInvitation.builder()
+            .user(user)
+            .phone(request.phone())
+            .name(request.name())
+            .relation(request.relation())
+            .isPrimary(request.isPrimary())
+            .build();
+        guardianInvitationRepository.save(invitation);
+
+        return new GuardianDto.ResponseInvite(
+            invitation.getId(),
+            invitation.getName(),
+            invitation.getPhone(),
+            invitation.getRelation(),
+            invitation.getIsPrimary(),
+            invitation.getStatus(),
+            invitation.getCreatedAt()
+        );
     }
 
     @Transactional

--- a/src/main/java/com/ikongserver/service/NotificationService.java
+++ b/src/main/java/com/ikongserver/service/NotificationService.java
@@ -68,6 +68,30 @@ public class NotificationService {
         );
     }
 
+    public NotificationListResponse getNotificationsByUserId(Long userId, String status, int page, int size) {
+        Page<Notification> result;
+
+        if (status != null && !status.isEmpty()) {
+            result = notificationRepository.findByUserIdAndStatus(
+                    userId, status, PageRequest.of(page - 1, size));
+        } else {
+            result = notificationRepository.findByUserId(
+                    userId, PageRequest.of(page - 1, size));
+        }
+
+        return new NotificationListResponse(
+                result.getTotalElements(),
+                result.getContent().stream()
+                        .map(n -> new NotificationItem(
+                                n.getId(),
+                                n.getMessage(),
+                                n.getStatus(),
+                                n.getSentAt(),
+                                n.getReadYN()))
+                        .toList()
+        );
+    }
+
     @Transactional
     public void markAsRead(Long notificationId) {
         Notification notification = notificationRepository.findById(notificationId)

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.application.name=iKong-server
+# dev(supabase) ↔ main(oracle) 으로만 바꾸면 전환 완료
 spring.profiles.active=dev


### PR DESCRIPTION
- POST /guardians/invite: 전화번호 기반 보호자 초대 (guardian_invitation 테이블)
- 카카오 로그인 시 PENDING 초대 자동 수락 → UserGuardianMap 생성
- GET /notifications: ROLE_USER(피보호자)도 알림 조회 가능하도록 수정
- Supabase(dev) / Oracle(main) Spring Profile 분리