### PR TITLE
feat:보호자 화면 알림 이력/비상이벤트 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = 'iKong-server'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(26)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/src/main/java/com/ikongserver/config/SecurityConfig.java
+++ b/src/main/java/com/ikongserver/config/SecurityConfig.java
@@ -31,6 +31,10 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/logout").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/notifications").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/notifications").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/notifications/unread-count").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/emergency_event/summary").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/emergency_event/alerts").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/api/emergency_event/resolve-all").authenticated()
                         .anyRequest().permitAll())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil),
                         UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/ikongserver/controller/EmergencyEventController.java
+++ b/src/main/java/com/ikongserver/controller/EmergencyEventController.java
@@ -1,10 +1,15 @@
 package com.ikongserver.controller;
 
+import com.ikongserver.dto.EventDto.EmergencyAlertListResponse;
+import com.ikongserver.dto.EventDto.EventSummaryResponse;
 import com.ikongserver.dto.EventDto.ResponseEvent;
 import com.ikongserver.service.EmergencyEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,10 +27,42 @@ public class EmergencyEventController {
         @PathVariable Long userId) {
 
         ResponseEvent response = emergencyEventService.getLatestPendingEvent(userId);
-
-        // 데이터가 없으면 204 No Content를 주거나, null을 포함한 200 OK를 줍니다.
         return ResponseEntity.ok(response);
+    }
 
+    // 보호자 기준 해결건/미해결건 요약
+    @GetMapping("/summary")
+    public ResponseEntity<EventSummaryResponse> getEventSummary(
+        @AuthenticationPrincipal UserDetails userDetails) {
+
+        Long guardianId = Long.parseLong(userDetails.getUsername());
+        return ResponseEntity.ok(emergencyEventService.getEventSummaryForGuardian(guardianId));
+    }
+
+    // 보호자 기준 긴급 알림 목록
+    @GetMapping("/alerts")
+    public ResponseEntity<EmergencyAlertListResponse> getEmergencyAlerts(
+        @AuthenticationPrincipal UserDetails userDetails) {
+
+        Long guardianId = Long.parseLong(userDetails.getUsername());
+        return ResponseEntity.ok(emergencyEventService.getEmergencyAlertsForGuardian(guardianId));
+    }
+
+    // 개별 이벤트 해결 처리
+    @PatchMapping("/{eventId}/resolve")
+    public ResponseEntity<Void> resolveEvent(@PathVariable Long eventId) {
+        emergencyEventService.resolveEvent(eventId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 보호자 기준 전체 이벤트 해결 처리
+    @PatchMapping("/resolve-all")
+    public ResponseEntity<Void> resolveAllEvents(
+        @AuthenticationPrincipal UserDetails userDetails) {
+
+        Long guardianId = Long.parseLong(userDetails.getUsername());
+        emergencyEventService.resolveAllEvents(guardianId);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/ikongserver/controller/GuardianController.java
+++ b/src/main/java/com/ikongserver/controller/GuardianController.java
@@ -49,6 +49,18 @@ public class GuardianController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
     }
 
+    @PostMapping("/invite/{invitationId}/accept")
+    public ResponseEntity<ApiResponse<Void>> acceptInvitation(@PathVariable Long invitationId) {
+        guardianService.acceptInvitation(invitationId);
+        return ResponseEntity.ok(ApiResponse.ok("초대를 수락했습니다.", null));
+    }
+
+    @PostMapping("/invite/{invitationId}/reject")
+    public ResponseEntity<ApiResponse<Void>> rejectInvitation(@PathVariable Long invitationId) {
+        guardianService.rejectInvitation(invitationId);
+        return ResponseEntity.ok(ApiResponse.ok("초대를 거절했습니다.", null));
+    }
+
     @DeleteMapping("/{guardianId}")
     public ResponseEntity<ApiResponse<Void>> deleteGuardian(
         @RequestParam Long userId, // TODO: JWT 인증 후 SecurityContext에서 userId 추출로 변경

--- a/src/main/java/com/ikongserver/controller/NotificationController.java
+++ b/src/main/java/com/ikongserver/controller/NotificationController.java
@@ -51,6 +51,13 @@ public class NotificationController {
         }
     }
 
+    @GetMapping("/unread-count")
+    public ResponseEntity<Long> getUnreadCount(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        Long guardianId = Long.parseLong(userDetails.getUsername());
+        return ResponseEntity.ok(notificationService.getUnreadCount(guardianId));
+    }
+
     @PatchMapping("/{notificationId}/read")
     public ResponseEntity<Void> markAsRead(@PathVariable Long notificationId) {
         notificationService.markAsRead(notificationId);

--- a/src/main/java/com/ikongserver/dto/EventDto.java
+++ b/src/main/java/com/ikongserver/dto/EventDto.java
@@ -1,6 +1,7 @@
 package com.ikongserver.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class EventDto {
 
@@ -15,4 +16,21 @@ public class EventDto {
                                    Long eventId) {
 
     }
+
+    // 보호자 화면 해결건/미해결건 요약
+    public record EventSummaryResponse(long resolvedCount, long unresolvedCount) {
+
+    }
+
+    // 보호자 화면 긴급 알림 목록
+    public record EmergencyAlertResponse(
+        Long id,
+        String userName,
+        String eventType,
+        String status,
+        LocalDateTime createdAt,
+        String detail
+    ) {}
+
+    public record EmergencyAlertListResponse(List<EmergencyAlertResponse> alerts) {}
 }

--- a/src/main/java/com/ikongserver/dto/NotificationDto.java
+++ b/src/main/java/com/ikongserver/dto/NotificationDto.java
@@ -9,7 +9,7 @@ public class NotificationDto {
 
     public record CreateNotificationResponse(Long notificationId, String message, LocalDateTime sentAt) {}
 
-    public record NotificationItem(Long notificationId, String message, String status, LocalDateTime sentAt, String readYN) {}
+    public record NotificationItem(Long notificationId, String userName, String eventType, String message, String status, LocalDateTime sentAt, String readYN) {}
 
     public record NotificationListResponse(long total, List<NotificationItem> notifications) {}
 }

--- a/src/main/java/com/ikongserver/entity/GuardianInvitation.java
+++ b/src/main/java/com/ikongserver/entity/GuardianInvitation.java
@@ -52,6 +52,10 @@ public class GuardianInvitation {
         this.status = "ACCEPTED";
     }
 
+    public void reject() {
+        this.status = "REJECTED";
+    }
+
     @Builder
     public GuardianInvitation(Users user, String phone, String name, String relation, Boolean isPrimary) {
         this.user = user;

--- a/src/main/java/com/ikongserver/entity/GuardianInvitation.java
+++ b/src/main/java/com/ikongserver/entity/GuardianInvitation.java
@@ -49,10 +49,16 @@ public class GuardianInvitation {
     private LocalDateTime createdAt;
 
     public void accept() {
+        if (!"PENDING".equals(this.status)) {
+            throw new IllegalStateException("이미 처리된 초대입니다.");
+        }
         this.status = "ACCEPTED";
     }
 
     public void reject() {
+        if (!"PENDING".equals(this.status)) {
+            throw new IllegalStateException("이미 처리된 초대입니다.");
+        }
         this.status = "REJECTED";
     }
 

--- a/src/main/java/com/ikongserver/repository/EmergencyEventRepository.java
+++ b/src/main/java/com/ikongserver/repository/EmergencyEventRepository.java
@@ -2,6 +2,7 @@ package com.ikongserver.repository;
 
 import com.ikongserver.entity.EmergencyEvent;
 import com.ikongserver.entity.Users;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,10 @@ public interface EmergencyEventRepository extends JpaRepository<EmergencyEvent, 
     boolean existsByUserAndStatus(Users user, String status);
 
     Optional<EmergencyEvent> findTopByUserAndStatusOrderByCreatedAtDesc(Users user, String status);
+
+    long countByUserInAndStatus(List<Users> users, String status);
+
+    List<EmergencyEvent> findByUserInOrderByCreatedAtDesc(List<Users> users);
+
+    List<EmergencyEvent> findByUserInAndStatus(List<Users> users, String status);
 }

--- a/src/main/java/com/ikongserver/repository/NotificationRepository.java
+++ b/src/main/java/com/ikongserver/repository/NotificationRepository.java
@@ -19,4 +19,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     @Query("SELECT n FROM Notification n WHERE n.emergencyEvent.user.id = :userId AND n.status = :status")
     Page<Notification> findByUserIdAndStatus(@Param("userId") Long userId, @Param("status") String status, Pageable pageable);
+
+    long countByGuardianIdAndReadYN(Long guardianId, String readYN);
 }

--- a/src/main/java/com/ikongserver/repository/UserGuardianMapRepository.java
+++ b/src/main/java/com/ikongserver/repository/UserGuardianMapRepository.java
@@ -10,6 +10,8 @@ public interface UserGuardianMapRepository extends JpaRepository<UserGuardianMap
 
     List<UserGuardianMap> findByUser(Users user);
 
+    List<UserGuardianMap> findByGuardian(Guardian guardian);
+
     long countByUserAndIsActive(Users user, String isActive);
 
     boolean existsByUserAndGuardian(Users user, Guardian guardian);

--- a/src/main/java/com/ikongserver/service/EmergencyEventService.java
+++ b/src/main/java/com/ikongserver/service/EmergencyEventService.java
@@ -92,6 +92,8 @@ public class EmergencyEventService {
             .map(UserGuardianMap::getUser)
             .toList();
 
+        if (users.isEmpty()) return new EventSummaryResponse(0, 0);
+
         long unresolvedCount = emergencyEventRepository.countByUserInAndStatus(users, "PENDING");
         long resolvedCount = emergencyEventRepository.countByUserInAndStatus(users, "RESOLVED");
 
@@ -107,6 +109,8 @@ public class EmergencyEventService {
         List<Users> users = userGuardianMapRepository.findByGuardian(guardian).stream()
             .map(UserGuardianMap::getUser)
             .toList();
+
+        if (users.isEmpty()) return new EmergencyAlertListResponse(List.of());
 
         List<EmergencyAlertResponse> alerts = emergencyEventRepository
             .findByUserInOrderByCreatedAtDesc(users).stream()
@@ -140,6 +144,8 @@ public class EmergencyEventService {
         List<Users> users = userGuardianMapRepository.findByGuardian(guardian).stream()
             .map(UserGuardianMap::getUser)
             .toList();
+
+        if (users.isEmpty()) return;
 
         emergencyEventRepository.findByUserInAndStatus(users, "PENDING")
             .forEach(event -> event.updateStatus("RESOLVED"));

--- a/src/main/java/com/ikongserver/service/EmergencyEventService.java
+++ b/src/main/java/com/ikongserver/service/EmergencyEventService.java
@@ -1,12 +1,20 @@
 package com.ikongserver.service;
 
+import com.ikongserver.dto.EventDto.EmergencyAlertListResponse;
+import com.ikongserver.dto.EventDto.EmergencyAlertResponse;
+import com.ikongserver.dto.EventDto.EventSummaryResponse;
 import com.ikongserver.dto.EventDto.ResponseEvent;
 import com.ikongserver.dto.VitalDto.VitalRequestDto;
 import com.ikongserver.entity.Device;
 import com.ikongserver.entity.EmergencyEvent;
+import com.ikongserver.entity.Guardian;
+import com.ikongserver.entity.UserGuardianMap;
 import com.ikongserver.entity.Users;
 import com.ikongserver.repository.EmergencyEventRepository;
+import com.ikongserver.repository.GuardianRepository;
+import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +25,8 @@ public class EmergencyEventService {
 
     private final EmergencyEventRepository emergencyEventRepository;
     private final UsersRepository userRepository;
+    private final GuardianRepository guardianRepository;
+    private final UserGuardianMapRepository userGuardianMapRepository;
 
     // 낙상 감지시 프론트에 낙상 감지 보내기
     // 낙상 감지시 데이터를 Emergency_Event 테이블에 DB 저장 Type은 낙상
@@ -70,6 +80,78 @@ public class EmergencyEventService {
         }
 
         return isIssueDetected;
+    }
+
+    // 보호자 기준 해결건/미해결건 요약
+    @Transactional(readOnly = true)
+    public EventSummaryResponse getEventSummaryForGuardian(Long guardianId) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+            .orElseThrow(() -> new IllegalArgumentException("보호자를 찾을 수 없습니다."));
+
+        List<Users> users = userGuardianMapRepository.findByGuardian(guardian).stream()
+            .map(UserGuardianMap::getUser)
+            .toList();
+
+        long unresolvedCount = emergencyEventRepository.countByUserInAndStatus(users, "PENDING");
+        long resolvedCount = emergencyEventRepository.countByUserInAndStatus(users, "RESOLVED");
+
+        return new EventSummaryResponse(resolvedCount, unresolvedCount);
+    }
+
+    // 보호자 기준 긴급 알림 목록
+    @Transactional(readOnly = true)
+    public EmergencyAlertListResponse getEmergencyAlertsForGuardian(Long guardianId) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+            .orElseThrow(() -> new IllegalArgumentException("보호자를 찾을 수 없습니다."));
+
+        List<Users> users = userGuardianMapRepository.findByGuardian(guardian).stream()
+            .map(UserGuardianMap::getUser)
+            .toList();
+
+        List<EmergencyAlertResponse> alerts = emergencyEventRepository
+            .findByUserInOrderByCreatedAtDesc(users).stream()
+            .map(event -> new EmergencyAlertResponse(
+                event.getId(),
+                event.getUser().getName(),
+                event.getEventType(),
+                event.getStatus(),
+                event.getCreatedAt(),
+                toDetail(event.getEventType())
+            ))
+            .toList();
+
+        return new EmergencyAlertListResponse(alerts);
+    }
+
+    // 개별 이벤트 해결 처리
+    @Transactional
+    public void resolveEvent(Long eventId) {
+        EmergencyEvent event = emergencyEventRepository.findById(eventId)
+            .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다."));
+        event.updateStatus("RESOLVED");
+    }
+
+    // 보호자 기준 전체 이벤트 해결 처리
+    @Transactional
+    public void resolveAllEvents(Long guardianId) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+            .orElseThrow(() -> new IllegalArgumentException("보호자를 찾을 수 없습니다."));
+
+        List<Users> users = userGuardianMapRepository.findByGuardian(guardian).stream()
+            .map(UserGuardianMap::getUser)
+            .toList();
+
+        emergencyEventRepository.findByUserInAndStatus(users, "PENDING")
+            .forEach(event -> event.updateStatus("RESOLVED"));
+    }
+
+    private String toDetail(String eventType) {
+        return switch (eventType) {
+            case "FALL" -> "낙상이 감지되었습니다.";
+            case "HEART_ISSUE" -> "심박수 이상이 감지되었습니다.";
+            case "BREATH_ISSUE" -> "호흡수 이상이 감지되었습니다.";
+            default -> "이상이 감지되었습니다.";
+        };
     }
 
     // 응급 상황 중 미해결 조회

--- a/src/main/java/com/ikongserver/service/GuardianService.java
+++ b/src/main/java/com/ikongserver/service/GuardianService.java
@@ -106,6 +106,20 @@ public class GuardianService {
     }
 
     @Transactional
+    public void acceptInvitation(Long invitationId) {
+        GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
+            .orElseThrow(() -> new IllegalArgumentException("초대를 찾을 수 없습니다."));
+        invitation.accept();
+    }
+
+    @Transactional
+    public void rejectInvitation(Long invitationId) {
+        GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
+            .orElseThrow(() -> new IllegalArgumentException("초대를 찾을 수 없습니다."));
+        invitation.reject();
+    }
+
+    @Transactional
     public void deleteGuardian(Long userId, Long guardianId) {
         Users user = usersRepository.findById(userId)
             .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));

--- a/src/main/java/com/ikongserver/service/NotificationService.java
+++ b/src/main/java/com/ikongserver/service/NotificationService.java
@@ -44,6 +44,7 @@ public class NotificationService {
         return new CreateNotificationResponse(notification.getId(), notification.getMessage(), notification.getSentAt());
     }
 
+    @Transactional(readOnly = true)
     public NotificationListResponse getNotifications(Long guardianId, String status, int page, int size) {
         Page<Notification> result;
 
@@ -60,6 +61,8 @@ public class NotificationService {
                 result.getContent().stream()
                         .map(n -> new NotificationItem(
                                 n.getId(),
+                                n.getEmergencyEvent().getUser().getName(),
+                                n.getEmergencyEvent().getEventType(),
                                 n.getMessage(),
                                 n.getStatus(),
                                 n.getSentAt(),
@@ -68,6 +71,7 @@ public class NotificationService {
         );
     }
 
+    @Transactional(readOnly = true)
     public NotificationListResponse getNotificationsByUserId(Long userId, String status, int page, int size) {
         Page<Notification> result;
 
@@ -84,12 +88,18 @@ public class NotificationService {
                 result.getContent().stream()
                         .map(n -> new NotificationItem(
                                 n.getId(),
+                                n.getEmergencyEvent().getUser().getName(),
+                                n.getEmergencyEvent().getEventType(),
                                 n.getMessage(),
                                 n.getStatus(),
                                 n.getSentAt(),
                                 n.getReadYN()))
                         .toList()
         );
+    }
+
+    public long getUnreadCount(Long guardianId) {
+        return notificationRepository.countByGuardianIdAndReadYN(guardianId, "N");
     }
 
     @Transactional

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.application.name=iKong-server
 # dev(supabase) ↔ main(oracle) 으로만 바꾸면 전환 완료
-spring.profiles.active=dev
+spring.profiles.active=main


### PR DESCRIPTION
## 변경 사항
- 보호자 화면 알림 이력 및 비상이벤트 관련 API 구현
- 구현 중 발견된 버그 2건 수정

## 작업 내용

- 알림 이력 조회 (userName, eventType 필드 추가, 역할별 분기)
- 미읽음 알림 수 조회
- 알림 읽음 처리
- 비상이벤트 해결/미해결 건수 요약
- 비상이벤트 알림 목록 조회
- 개별 이벤트 해결 처리
- 전체 이벤트 일괄 해결 처리
- 보호자 초대 수락
- 보호자 초대 거절

### 버그 수정
- EmergencyEventService — 보호자에게 연결된 피보호자가 없을 때 빈 리스트로 IN 쿼리 실행 시 SQL 오류 발생 → 조기 반환으로 수정
- GuardianInvitation — 이미 수락/거절된 초대를 중복 처리할 수 있던 문제 → 상태 검증 추가

### 코드 품질 수정
- NotificationService — LAZY 로딩 안전 처리를 위해 @Transactional(readOnly = true) 추가
- SecurityConfig — @AuthenticationPrincipal 사용 엔드포인트에 `.authenticated()` 규칙 추가

## 테스트
- 서버 로컬 실행 확인 

