### PR TITLE
feat: 알림 이력 화면 API 구현 및 머지 충돌 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ description = 'iKong-server'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(26)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/src/main/java/com/ikongserver/config/SecurityConfig.java
+++ b/src/main/java/com/ikongserver/config/SecurityConfig.java
@@ -23,21 +23,28 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                // JWT 기반 Stateless 인증 사용 — CSRF, 세션 불필요
                 .csrf(AbstractHttpConfigurer::disable)
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        // 회원가입, 로그인, 토큰 갱신은 인증 없이 허용
                         .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/refresh").permitAll()
+                        // 로그아웃은 유효한 JWT 토큰 필요
                         .requestMatchers("/api/v1/auth/logout").authenticated()
+                        // 알림 생성은 IoT 기기/서버에서 호출하므로 인증 없이 허용, 조회는 보호자 JWT 필요
                         .requestMatchers(HttpMethod.POST, "/api/v1/notifications").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/notifications").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/v1/notifications/unread-count").authenticated()
+                        // 응급 이벤트 조회/처리는 보호자 JWT 필요
                         .requestMatchers(HttpMethod.GET, "/api/emergency_event/summary").authenticated()
                         .requestMatchers(HttpMethod.GET, "/api/emergency_event/alerts").authenticated()
                         .requestMatchers(HttpMethod.PATCH, "/api/emergency_event/resolve-all").authenticated()
                         .requestMatchers(HttpMethod.PATCH, "/api/emergency_event/*/resolve").authenticated()
+                        // 보호자 내 정보 관련 API는 JWT 필요
                         .requestMatchers("/api/v1/guardians/me/**").authenticated()
                         .anyRequest().permitAll())
+                // JWT 필터를 UsernamePasswordAuthenticationFilter 앞에 삽입하여 토큰 인증 처리
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil),
                         UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/com/ikongserver/config/SecurityConfig.java
+++ b/src/main/java/com/ikongserver/config/SecurityConfig.java
@@ -31,6 +31,10 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/logout").authenticated()
                         .requestMatchers(HttpMethod.POST, "/api/v1/notifications").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/notifications").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/notifications/unread-count").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/emergency_event/summary").authenticated()
+                        .requestMatchers(HttpMethod.GET, "/api/emergency_event/alerts").authenticated()
+                        .requestMatchers(HttpMethod.PATCH, "/api/emergency_event/resolve-all").authenticated()
                         .anyRequest().permitAll())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtUtil),
                         UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/ikongserver/controller/EmergencyEventController.java
+++ b/src/main/java/com/ikongserver/controller/EmergencyEventController.java
@@ -14,6 +14,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 응급 이벤트 API 컨트롤러
+ * - 피보호자 앱: 본인의 미해결 이벤트 조회
+ * - 보호자 앱: 이벤트 요약, 목록 조회, 해결 처리
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/emergency_event")
@@ -21,14 +26,14 @@ public class EmergencyEventController {
 
     private final EmergencyEventService emergencyEventService;
 
-    // 응급 이슈 프론트 전달
+    // [피보호자용] 본인의 가장 최근 미처리(PENDING) 응급 이벤트 1건 반환 — 앱 화면에 팝업 표시용
     @GetMapping("{userId}/emergency")
     public ResponseEntity<ResponseEvent> getLatestEmergencyEvent(@PathVariable Long userId) {
         ResponseEvent response = emergencyEventService.getLatestPendingEvent(userId);
         return ResponseEntity.ok(response);
     }
 
-    // 보호자 기준 해결건/미해결건 요약
+    // [보호자용] 담당 피보호자 전체의 해결된 이벤트 수 / 미해결 이벤트 수 요약 반환
     @GetMapping("/summary")
     public ResponseEntity<EventSummaryResponse> getEventSummary(
         @AuthenticationPrincipal UserDetails userDetails) {
@@ -36,7 +41,7 @@ public class EmergencyEventController {
         return ResponseEntity.ok(emergencyEventService.getEventSummaryForGuardian(guardianId));
     }
 
-    // 보호자 기준 긴급 알림 목록
+    // [보호자용] 담당 피보호자 전체의 응급 이벤트 목록을 최신순으로 반환
     @GetMapping("/alerts")
     public ResponseEntity<EmergencyAlertListResponse> getEmergencyAlerts(
         @AuthenticationPrincipal UserDetails userDetails) {
@@ -44,7 +49,7 @@ public class EmergencyEventController {
         return ResponseEntity.ok(emergencyEventService.getEmergencyAlertsForGuardian(guardianId));
     }
 
-    // 개별 이벤트 해결 처리
+    // [보호자용] 특정 이벤트를 RESOLVED로 변경 — 권한 없는 보호자가 처리하면 403 반환
     @PatchMapping("/{eventId}/resolve")
     public ResponseEntity<ResponseEvent> resolveEvent(
         @AuthenticationPrincipal UserDetails userDetails,
@@ -53,7 +58,7 @@ public class EmergencyEventController {
         return ResponseEntity.ok(emergencyEventService.resolveEvent(guardianId, eventId));
     }
 
-    // 보호자 기준 전체 이벤트 해결 처리
+    // [보호자용] 담당 피보호자의 미해결(PENDING) 이벤트 전체를 한 번에 RESOLVED 처리
     @PatchMapping("/resolve-all")
     public ResponseEntity<Void> resolveAllEvents(
         @AuthenticationPrincipal UserDetails userDetails) {

--- a/src/main/java/com/ikongserver/controller/EmergencyEventController.java
+++ b/src/main/java/com/ikongserver/controller/EmergencyEventController.java
@@ -1,10 +1,15 @@
 package com.ikongserver.controller;
 
+import com.ikongserver.dto.EventDto.EmergencyAlertListResponse;
+import com.ikongserver.dto.EventDto.EventSummaryResponse;
 import com.ikongserver.dto.EventDto.ResponseEvent;
 import com.ikongserver.service.EmergencyEventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,10 +27,42 @@ public class EmergencyEventController {
         @PathVariable Long userId) {
 
         ResponseEvent response = emergencyEventService.getLatestPendingEvent(userId);
-
-        // 데이터가 없으면 204 No Content를 주거나, null을 포함한 200 OK를 줍니다.
         return ResponseEntity.ok(response);
+    }
 
+    // 보호자 기준 해결건/미해결건 요약
+    @GetMapping("/summary")
+    public ResponseEntity<EventSummaryResponse> getEventSummary(
+        @AuthenticationPrincipal UserDetails userDetails) {
+
+        Long guardianId = Long.parseLong(userDetails.getUsername());
+        return ResponseEntity.ok(emergencyEventService.getEventSummaryForGuardian(guardianId));
+    }
+
+    // 보호자 기준 긴급 알림 목록
+    @GetMapping("/alerts")
+    public ResponseEntity<EmergencyAlertListResponse> getEmergencyAlerts(
+        @AuthenticationPrincipal UserDetails userDetails) {
+
+        Long guardianId = Long.parseLong(userDetails.getUsername());
+        return ResponseEntity.ok(emergencyEventService.getEmergencyAlertsForGuardian(guardianId));
+    }
+
+    // 개별 이벤트 해결 처리
+    @PatchMapping("/{eventId}/resolve")
+    public ResponseEntity<Void> resolveEvent(@PathVariable Long eventId) {
+        emergencyEventService.resolveEvent(eventId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 보호자 기준 전체 이벤트 해결 처리
+    @PatchMapping("/resolve-all")
+    public ResponseEntity<Void> resolveAllEvents(
+        @AuthenticationPrincipal UserDetails userDetails) {
+
+        Long guardianId = Long.parseLong(userDetails.getUsername());
+        emergencyEventService.resolveAllEvents(guardianId);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/com/ikongserver/controller/GuardianController.java
+++ b/src/main/java/com/ikongserver/controller/GuardianController.java
@@ -49,6 +49,18 @@ public class GuardianController {
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.created(response));
     }
 
+    @PostMapping("/invite/{invitationId}/accept")
+    public ResponseEntity<ApiResponse<Void>> acceptInvitation(@PathVariable Long invitationId) {
+        guardianService.acceptInvitation(invitationId);
+        return ResponseEntity.ok(ApiResponse.ok("초대를 수락했습니다.", null));
+    }
+
+    @PostMapping("/invite/{invitationId}/reject")
+    public ResponseEntity<ApiResponse<Void>> rejectInvitation(@PathVariable Long invitationId) {
+        guardianService.rejectInvitation(invitationId);
+        return ResponseEntity.ok(ApiResponse.ok("초대를 거절했습니다.", null));
+    }
+
     @DeleteMapping("/{guardianId}")
     public ResponseEntity<ApiResponse<Void>> deleteGuardian(
         @RequestParam Long userId, // TODO: JWT 인증 후 SecurityContext에서 userId 추출로 변경

--- a/src/main/java/com/ikongserver/controller/NotificationController.java
+++ b/src/main/java/com/ikongserver/controller/NotificationController.java
@@ -51,6 +51,13 @@ public class NotificationController {
         }
     }
 
+    @GetMapping("/unread-count")
+    public ResponseEntity<Long> getUnreadCount(
+            @AuthenticationPrincipal UserDetails userDetails) {
+        Long guardianId = Long.parseLong(userDetails.getUsername());
+        return ResponseEntity.ok(notificationService.getUnreadCount(guardianId));
+    }
+
     @PatchMapping("/{notificationId}/read")
     public ResponseEntity<Void> markAsRead(@PathVariable Long notificationId) {
         notificationService.markAsRead(notificationId);

--- a/src/main/java/com/ikongserver/controller/NotificationController.java
+++ b/src/main/java/com/ikongserver/controller/NotificationController.java
@@ -17,6 +17,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 알림(Notification) API 컨트롤러
+ * - 알림 생성: IoT 기기/서버가 응급 이벤트 발생 시 호출 (인증 불필요)
+ * - 알림 조회: 보호자는 자신에게 온 알림, 피보호자는 본인 관련 알림 조회
+ */
 @RestController
 @RequestMapping("/api/v1/notifications")
 @RequiredArgsConstructor
@@ -24,12 +29,14 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
+    // 응급 이벤트 발생 시 알림 생성 — IoT 기기나 내부 서버에서 호출, JWT 인증 불필요
     @PostMapping
     public ResponseEntity<CreateNotificationResponse> createNotification(
             @RequestBody CreateNotificationRequest request) {
         return ResponseEntity.ok(notificationService.createNotification(request));
     }
 
+    // 알림 목록 조회 — ROLE_GUARDIAN이면 guardianId, 피보호자면 userId 기준으로 조회 (페이징, 상태 필터 지원)
     @GetMapping
     public ResponseEntity<NotificationListResponse> getNotifications(
             @AuthenticationPrincipal UserDetails userDetails,
@@ -51,6 +58,7 @@ public class NotificationController {
         }
     }
 
+    // 보호자의 읽지 않은(readYN=N) 알림 수 반환 — 앱 뱃지 표시용
     @GetMapping("/unread-count")
     public ResponseEntity<Long> getUnreadCount(
             @AuthenticationPrincipal UserDetails userDetails) {
@@ -58,6 +66,7 @@ public class NotificationController {
         return ResponseEntity.ok(notificationService.getUnreadCount(guardianId));
     }
 
+    // 특정 알림을 읽음(readYN=Y)으로 변경
     @PatchMapping("/{notificationId}/read")
     public ResponseEntity<Void> markAsRead(@PathVariable Long notificationId) {
         notificationService.markAsRead(notificationId);

--- a/src/main/java/com/ikongserver/dto/EventDto.java
+++ b/src/main/java/com/ikongserver/dto/EventDto.java
@@ -1,6 +1,7 @@
 package com.ikongserver.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class EventDto {
 
@@ -15,4 +16,21 @@ public class EventDto {
                                    Long eventId) {
 
     }
+
+    // 보호자 화면 해결건/미해결건 요약
+    public record EventSummaryResponse(long resolvedCount, long unresolvedCount) {
+
+    }
+
+    // 보호자 화면 긴급 알림 목록
+    public record EmergencyAlertResponse(
+        Long id,
+        String userName,
+        String eventType,
+        String status,
+        LocalDateTime createdAt,
+        String detail
+    ) {}
+
+    public record EmergencyAlertListResponse(List<EmergencyAlertResponse> alerts) {}
 }

--- a/src/main/java/com/ikongserver/dto/NotificationDto.java
+++ b/src/main/java/com/ikongserver/dto/NotificationDto.java
@@ -9,7 +9,7 @@ public class NotificationDto {
 
     public record CreateNotificationResponse(Long notificationId, String message, LocalDateTime sentAt) {}
 
-    public record NotificationItem(Long notificationId, String message, String status, LocalDateTime sentAt, String readYN) {}
+    public record NotificationItem(Long notificationId, String userName, String eventType, String message, String status, LocalDateTime sentAt, String readYN) {}
 
     public record NotificationListResponse(long total, List<NotificationItem> notifications) {}
 }

--- a/src/main/java/com/ikongserver/entity/GuardianInvitation.java
+++ b/src/main/java/com/ikongserver/entity/GuardianInvitation.java
@@ -52,6 +52,10 @@ public class GuardianInvitation {
         this.status = "ACCEPTED";
     }
 
+    public void reject() {
+        this.status = "REJECTED";
+    }
+
     @Builder
     public GuardianInvitation(Users user, String phone, String name, String relation, Boolean isPrimary) {
         this.user = user;

--- a/src/main/java/com/ikongserver/entity/GuardianInvitation.java
+++ b/src/main/java/com/ikongserver/entity/GuardianInvitation.java
@@ -48,6 +48,7 @@ public class GuardianInvitation {
     @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    // 초대 수락 — 이미 수락/거절된 초대를 중복 처리하지 않도록 PENDING 상태일 때만 허용
     public void accept() {
         if (!"PENDING".equals(this.status)) {
             throw new IllegalStateException("이미 처리된 초대입니다.");
@@ -55,6 +56,7 @@ public class GuardianInvitation {
         this.status = "ACCEPTED";
     }
 
+    // 초대 거절 — 이미 수락/거절된 초대를 중복 처리하지 않도록 PENDING 상태일 때만 허용
     public void reject() {
         if (!"PENDING".equals(this.status)) {
             throw new IllegalStateException("이미 처리된 초대입니다.");

--- a/src/main/java/com/ikongserver/entity/GuardianInvitation.java
+++ b/src/main/java/com/ikongserver/entity/GuardianInvitation.java
@@ -49,10 +49,16 @@ public class GuardianInvitation {
     private LocalDateTime createdAt;
 
     public void accept() {
+        if (!"PENDING".equals(this.status)) {
+            throw new IllegalStateException("이미 처리된 초대입니다.");
+        }
         this.status = "ACCEPTED";
     }
 
     public void reject() {
+        if (!"PENDING".equals(this.status)) {
+            throw new IllegalStateException("이미 처리된 초대입니다.");
+        }
         this.status = "REJECTED";
     }
 

--- a/src/main/java/com/ikongserver/repository/EmergencyEventRepository.java
+++ b/src/main/java/com/ikongserver/repository/EmergencyEventRepository.java
@@ -8,15 +8,21 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmergencyEventRepository extends JpaRepository<EmergencyEvent, Long> {
 
+    // 특정 사용자에게 해당 상태의 이벤트가 존재하는지 확인 (중복 알림 방지용)
     boolean existsByUserAndStatus(Users user, String status);
 
+    // 특정 사용자의 가장 최근 미해결 이벤트 1건 조회 (피보호자 앱 화면 표시용)
     Optional<EmergencyEvent> findTopByUserAndStatusOrderByCreatedAtDesc(Users user, String status);
 
+    // 보호자가 담당하는 여러 피보호자의 상태별 이벤트 수 집계 (요약 화면용)
     long countByUserInAndStatus(List<Users> users, String status);
 
+    // 보호자가 담당하는 여러 피보호자의 전체 이벤트 목록 조회, 최신순 정렬
     List<EmergencyEvent> findByUserInOrderByCreatedAtDesc(List<Users> users);
 
+    // 보호자가 담당하는 여러 피보호자 중 특정 상태(PENDING/RESOLVED)의 이벤트 목록 조회
     List<EmergencyEvent> findByUserInAndStatus(List<Users> users, String status);
 
+    // 단일 사용자의 상태별 이벤트 수 집계
     long countByUserAndStatus(Users user, String status);
 }

--- a/src/main/java/com/ikongserver/repository/EmergencyEventRepository.java
+++ b/src/main/java/com/ikongserver/repository/EmergencyEventRepository.java
@@ -2,6 +2,7 @@ package com.ikongserver.repository;
 
 import com.ikongserver.entity.EmergencyEvent;
 import com.ikongserver.entity.Users;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -10,4 +11,10 @@ public interface EmergencyEventRepository extends JpaRepository<EmergencyEvent, 
     boolean existsByUserAndStatus(Users user, String status);
 
     Optional<EmergencyEvent> findTopByUserAndStatusOrderByCreatedAtDesc(Users user, String status);
+
+    long countByUserInAndStatus(List<Users> users, String status);
+
+    List<EmergencyEvent> findByUserInOrderByCreatedAtDesc(List<Users> users);
+
+    List<EmergencyEvent> findByUserInAndStatus(List<Users> users, String status);
 }

--- a/src/main/java/com/ikongserver/repository/NotificationRepository.java
+++ b/src/main/java/com/ikongserver/repository/NotificationRepository.java
@@ -19,4 +19,6 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
 
     @Query("SELECT n FROM Notification n WHERE n.emergencyEvent.user.id = :userId AND n.status = :status")
     Page<Notification> findByUserIdAndStatus(@Param("userId") Long userId, @Param("status") String status, Pageable pageable);
+
+    long countByGuardianIdAndReadYN(Long guardianId, String readYN);
 }

--- a/src/main/java/com/ikongserver/repository/UserGuardianMapRepository.java
+++ b/src/main/java/com/ikongserver/repository/UserGuardianMapRepository.java
@@ -10,6 +10,8 @@ public interface UserGuardianMapRepository extends JpaRepository<UserGuardianMap
 
     List<UserGuardianMap> findByUser(Users user);
 
+    List<UserGuardianMap> findByGuardian(Guardian guardian);
+
     long countByUserAndIsActive(Users user, String isActive);
 
     boolean existsByUserAndGuardian(Users user, Guardian guardian);

--- a/src/main/java/com/ikongserver/service/EmergencyEventService.java
+++ b/src/main/java/com/ikongserver/service/EmergencyEventService.java
@@ -92,6 +92,8 @@ public class EmergencyEventService {
             .map(UserGuardianMap::getUser)
             .toList();
 
+        if (users.isEmpty()) return new EventSummaryResponse(0, 0);
+
         long unresolvedCount = emergencyEventRepository.countByUserInAndStatus(users, "PENDING");
         long resolvedCount = emergencyEventRepository.countByUserInAndStatus(users, "RESOLVED");
 
@@ -107,6 +109,8 @@ public class EmergencyEventService {
         List<Users> users = userGuardianMapRepository.findByGuardian(guardian).stream()
             .map(UserGuardianMap::getUser)
             .toList();
+
+        if (users.isEmpty()) return new EmergencyAlertListResponse(List.of());
 
         List<EmergencyAlertResponse> alerts = emergencyEventRepository
             .findByUserInOrderByCreatedAtDesc(users).stream()
@@ -140,6 +144,8 @@ public class EmergencyEventService {
         List<Users> users = userGuardianMapRepository.findByGuardian(guardian).stream()
             .map(UserGuardianMap::getUser)
             .toList();
+
+        if (users.isEmpty()) return;
 
         emergencyEventRepository.findByUserInAndStatus(users, "PENDING")
             .forEach(event -> event.updateStatus("RESOLVED"));

--- a/src/main/java/com/ikongserver/service/EmergencyEventService.java
+++ b/src/main/java/com/ikongserver/service/EmergencyEventService.java
@@ -28,6 +28,7 @@ public class EmergencyEventService {
     private final GuardianRepository guardianRepository;
     private final UserGuardianMapRepository userGuardianMapRepository;
 
+    // 낙상 감지 여부 확인 — isFallDetected=true면 FALL 이벤트 저장 후 true 반환 (VitalService에서 호출)
     public boolean checkFallEvent(VitalRequestDto vitalDto, Users user, Device device) {
         if (vitalDto.isFallDetected()) {
             EmergencyEvent fallEvent = EmergencyEvent.builder()
@@ -42,6 +43,7 @@ public class EmergencyEventService {
         return false;
     }
 
+    // 심박수(60~120 정상) / 호흡수(10~30 정상) 이상 여부 확인 — 범위 초과 시 각각 이벤트 저장
     public boolean checkHeartBreathEvent(VitalRequestDto vitalDto, Users user, Device device) {
         boolean isIssueDetected = false;
 
@@ -70,7 +72,7 @@ public class EmergencyEventService {
         return isIssueDetected;
     }
 
-    // 보호자 기준 해결건/미해결건 요약
+    // 보호자 ID로 담당 피보호자 전체의 해결/미해결 이벤트 수를 집계하여 반환
     @Transactional(readOnly = true)
     public EventSummaryResponse getEventSummaryForGuardian(Long guardianId) {
         Guardian guardian = guardianRepository.findById(guardianId)
@@ -88,7 +90,7 @@ public class EmergencyEventService {
         return new EventSummaryResponse(resolvedCount, unresolvedCount);
     }
 
-    // 보호자 기준 긴급 알림 목록
+    // 보호자 ID로 담당 피보호자 전체의 응급 이벤트 목록을 최신순으로 조회 (이벤트 타입별 상세 설명 포함)
     @Transactional(readOnly = true)
     public EmergencyAlertListResponse getEmergencyAlertsForGuardian(Long guardianId) {
         Guardian guardian = guardianRepository.findById(guardianId)
@@ -115,7 +117,7 @@ public class EmergencyEventService {
         return new EmergencyAlertListResponse(alerts);
     }
 
-    // 개별 이벤트 해결 처리 (권한 체크 포함)
+    // 특정 이벤트를 RESOLVED로 변경 — 해당 보호자가 담당하는 피보호자의 이벤트인지 권한 검증 후 처리
     @Transactional
     public ResponseEvent resolveEvent(Long guardianId, Long eventId) {
         Guardian guardian = guardianRepository.findById(guardianId)
@@ -139,7 +141,7 @@ public class EmergencyEventService {
         return new ResponseEvent(event.getId(), event.getEventType(), event.getStatus(), event.getCreatedAt());
     }
 
-    // 보호자 기준 전체 이벤트 해결 처리
+    // 보호자 ID로 담당 피보호자 전체의 PENDING 이벤트를 한 번에 RESOLVED로 일괄 처리
     @Transactional
     public void resolveAllEvents(Long guardianId) {
         Guardian guardian = guardianRepository.findById(guardianId)
@@ -164,7 +166,7 @@ public class EmergencyEventService {
         };
     }
 
-    // 응급 상황 중 미해결 조회
+    // 피보호자 ID로 가장 최근 PENDING 이벤트 1건 조회 — 없으면 null 반환 (앱 팝업 표시 여부 판단용)
     @Transactional(readOnly = true)
     public ResponseEvent getLatestPendingEvent(long userId) {
         Users user = userRepository.findById(userId)

--- a/src/main/java/com/ikongserver/service/EmergencyEventService.java
+++ b/src/main/java/com/ikongserver/service/EmergencyEventService.java
@@ -1,12 +1,20 @@
 package com.ikongserver.service;
 
+import com.ikongserver.dto.EventDto.EmergencyAlertListResponse;
+import com.ikongserver.dto.EventDto.EmergencyAlertResponse;
+import com.ikongserver.dto.EventDto.EventSummaryResponse;
 import com.ikongserver.dto.EventDto.ResponseEvent;
 import com.ikongserver.dto.VitalDto.VitalRequestDto;
 import com.ikongserver.entity.Device;
 import com.ikongserver.entity.EmergencyEvent;
+import com.ikongserver.entity.Guardian;
+import com.ikongserver.entity.UserGuardianMap;
 import com.ikongserver.entity.Users;
 import com.ikongserver.repository.EmergencyEventRepository;
+import com.ikongserver.repository.GuardianRepository;
+import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +25,8 @@ public class EmergencyEventService {
 
     private final EmergencyEventRepository emergencyEventRepository;
     private final UsersRepository userRepository;
+    private final GuardianRepository guardianRepository;
+    private final UserGuardianMapRepository userGuardianMapRepository;
 
     // 낙상 감지시 프론트에 낙상 감지 보내기
     // 낙상 감지시 데이터를 Emergency_Event 테이블에 DB 저장 Type은 낙상
@@ -70,6 +80,78 @@ public class EmergencyEventService {
         }
 
         return isIssueDetected;
+    }
+
+    // 보호자 기준 해결건/미해결건 요약
+    @Transactional(readOnly = true)
+    public EventSummaryResponse getEventSummaryForGuardian(Long guardianId) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+            .orElseThrow(() -> new IllegalArgumentException("보호자를 찾을 수 없습니다."));
+
+        List<Users> users = userGuardianMapRepository.findByGuardian(guardian).stream()
+            .map(UserGuardianMap::getUser)
+            .toList();
+
+        long unresolvedCount = emergencyEventRepository.countByUserInAndStatus(users, "PENDING");
+        long resolvedCount = emergencyEventRepository.countByUserInAndStatus(users, "RESOLVED");
+
+        return new EventSummaryResponse(resolvedCount, unresolvedCount);
+    }
+
+    // 보호자 기준 긴급 알림 목록
+    @Transactional(readOnly = true)
+    public EmergencyAlertListResponse getEmergencyAlertsForGuardian(Long guardianId) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+            .orElseThrow(() -> new IllegalArgumentException("보호자를 찾을 수 없습니다."));
+
+        List<Users> users = userGuardianMapRepository.findByGuardian(guardian).stream()
+            .map(UserGuardianMap::getUser)
+            .toList();
+
+        List<EmergencyAlertResponse> alerts = emergencyEventRepository
+            .findByUserInOrderByCreatedAtDesc(users).stream()
+            .map(event -> new EmergencyAlertResponse(
+                event.getId(),
+                event.getUser().getName(),
+                event.getEventType(),
+                event.getStatus(),
+                event.getCreatedAt(),
+                toDetail(event.getEventType())
+            ))
+            .toList();
+
+        return new EmergencyAlertListResponse(alerts);
+    }
+
+    // 개별 이벤트 해결 처리
+    @Transactional
+    public void resolveEvent(Long eventId) {
+        EmergencyEvent event = emergencyEventRepository.findById(eventId)
+            .orElseThrow(() -> new IllegalArgumentException("이벤트를 찾을 수 없습니다."));
+        event.updateStatus("RESOLVED");
+    }
+
+    // 보호자 기준 전체 이벤트 해결 처리
+    @Transactional
+    public void resolveAllEvents(Long guardianId) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+            .orElseThrow(() -> new IllegalArgumentException("보호자를 찾을 수 없습니다."));
+
+        List<Users> users = userGuardianMapRepository.findByGuardian(guardian).stream()
+            .map(UserGuardianMap::getUser)
+            .toList();
+
+        emergencyEventRepository.findByUserInAndStatus(users, "PENDING")
+            .forEach(event -> event.updateStatus("RESOLVED"));
+    }
+
+    private String toDetail(String eventType) {
+        return switch (eventType) {
+            case "FALL" -> "낙상이 감지되었습니다.";
+            case "HEART_ISSUE" -> "심박수 이상이 감지되었습니다.";
+            case "BREATH_ISSUE" -> "호흡수 이상이 감지되었습니다.";
+            default -> "이상이 감지되었습니다.";
+        };
     }
 
     // 응급 상황 중 미해결 조회

--- a/src/main/java/com/ikongserver/service/GuardianService.java
+++ b/src/main/java/com/ikongserver/service/GuardianService.java
@@ -106,6 +106,20 @@ public class GuardianService {
     }
 
     @Transactional
+    public void acceptInvitation(Long invitationId) {
+        GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
+            .orElseThrow(() -> new IllegalArgumentException("초대를 찾을 수 없습니다."));
+        invitation.accept();
+    }
+
+    @Transactional
+    public void rejectInvitation(Long invitationId) {
+        GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
+            .orElseThrow(() -> new IllegalArgumentException("초대를 찾을 수 없습니다."));
+        invitation.reject();
+    }
+
+    @Transactional
     public void deleteGuardian(Long userId, Long guardianId) {
         Users user = usersRepository.findById(userId)
             .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));

--- a/src/main/java/com/ikongserver/service/GuardianService.java
+++ b/src/main/java/com/ikongserver/service/GuardianService.java
@@ -26,6 +26,7 @@ public class GuardianService {
     private final UserGuardianMapRepository userGuardianMapRepository;
     private final UsersRepository usersRepository;
 
+    // 보호자 직접 등록 — 최대 5명 제한 초과 시 예외 발생, Guardian + UserGuardianMap 동시 생성
     @Transactional
     public GuardianDto.ResponseRegister registerGuardian(Long userId, GuardianDto.RequestRegister request) {
         Users user = usersRepository.findById(userId)
@@ -63,6 +64,7 @@ public class GuardianService {
         );
     }
 
+    // 피보호자 ID로 등록된 보호자 목록 조회 (활성/비활성 포함)
     public List<GuardianDto.ResponseGuardian> getGuardians(Long userId) {
         Users user = usersRepository.findById(userId)
             .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
@@ -80,6 +82,7 @@ public class GuardianService {
             .toList();
     }
 
+    // 보호자 초대 발송 — GuardianInvitation 레코드 생성, 초대 수락 전까지 UserGuardianMap에 반영 안 됨
     @Transactional
     public GuardianDto.ResponseInvite inviteGuardian(Long userId, GuardianDto.RequestInvite request) {
         Users user = usersRepository.findById(userId)
@@ -105,6 +108,7 @@ public class GuardianService {
         );
     }
 
+    // 초대 수락 — GuardianInvitation status를 ACCEPTED로 변경 (중복 처리 방지는 entity에서 검증)
     @Transactional
     public void acceptInvitation(Long invitationId) {
         GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
@@ -112,6 +116,7 @@ public class GuardianService {
         invitation.accept();
     }
 
+    // 초대 거절 — GuardianInvitation status를 REJECTED로 변경 (중복 처리 방지는 entity에서 검증)
     @Transactional
     public void rejectInvitation(Long invitationId) {
         GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
@@ -119,6 +124,7 @@ public class GuardianService {
         invitation.reject();
     }
 
+    // 보호자 삭제 — 실제 레코드 삭제 대신 UserGuardianMap의 isActive를 "N"으로 변경 (소프트 삭제)
     @Transactional
     public void deleteGuardian(Long userId, Long guardianId) {
         Users user = usersRepository.findById(userId)

--- a/src/main/java/com/ikongserver/service/NotificationService.java
+++ b/src/main/java/com/ikongserver/service/NotificationService.java
@@ -24,6 +24,7 @@ public class NotificationService {
     private final EmergencyEventRepository emergencyEventRepository;
     private final GuardianRepository guardianRepository;
 
+    // 응급 이벤트와 연결된 알림 생성 — status 미입력 시 기본값 "SUCCESS" 저장
     @Transactional
     public CreateNotificationResponse createNotification(CreateNotificationRequest request) {
         EmergencyEvent event = emergencyEventRepository.findById(request.eventId())
@@ -44,6 +45,7 @@ public class NotificationService {
         return new CreateNotificationResponse(notification.getId(), notification.getMessage(), notification.getSentAt());
     }
 
+    // 보호자 ID 기준 알림 목록 조회 — status 파라미터가 있으면 상태 필터 적용, 없으면 전체 반환 (페이징)
     @Transactional(readOnly = true)
     public NotificationListResponse getNotifications(Long guardianId, String status, int page, int size) {
         Page<Notification> result;
@@ -71,6 +73,7 @@ public class NotificationService {
         );
     }
 
+    // 피보호자 ID 기준 알림 목록 조회 — 본인과 연결된 응급 이벤트의 알림만 반환 (페이징)
     @Transactional(readOnly = true)
     public NotificationListResponse getNotificationsByUserId(Long userId, String status, int page, int size) {
         Page<Notification> result;
@@ -98,10 +101,12 @@ public class NotificationService {
         );
     }
 
+    // 보호자의 읽지 않은 알림 수 반환
     public long getUnreadCount(Long guardianId) {
         return notificationRepository.countByGuardianIdAndReadYN(guardianId, "N");
     }
 
+    // 특정 알림을 읽음 처리 — JPA dirty checking으로 별도 save() 없이 DB 반영
     @Transactional
     public void markAsRead(Long notificationId) {
         Notification notification = notificationRepository.findById(notificationId)

--- a/src/main/java/com/ikongserver/service/NotificationService.java
+++ b/src/main/java/com/ikongserver/service/NotificationService.java
@@ -44,6 +44,7 @@ public class NotificationService {
         return new CreateNotificationResponse(notification.getId(), notification.getMessage(), notification.getSentAt());
     }
 
+    @Transactional(readOnly = true)
     public NotificationListResponse getNotifications(Long guardianId, String status, int page, int size) {
         Page<Notification> result;
 
@@ -60,6 +61,8 @@ public class NotificationService {
                 result.getContent().stream()
                         .map(n -> new NotificationItem(
                                 n.getId(),
+                                n.getEmergencyEvent().getUser().getName(),
+                                n.getEmergencyEvent().getEventType(),
                                 n.getMessage(),
                                 n.getStatus(),
                                 n.getSentAt(),
@@ -68,6 +71,7 @@ public class NotificationService {
         );
     }
 
+    @Transactional(readOnly = true)
     public NotificationListResponse getNotificationsByUserId(Long userId, String status, int page, int size) {
         Page<Notification> result;
 
@@ -84,12 +88,18 @@ public class NotificationService {
                 result.getContent().stream()
                         .map(n -> new NotificationItem(
                                 n.getId(),
+                                n.getEmergencyEvent().getUser().getName(),
+                                n.getEmergencyEvent().getEventType(),
                                 n.getMessage(),
                                 n.getStatus(),
                                 n.getSentAt(),
                                 n.getReadYN()))
                         .toList()
         );
+    }
+
+    public long getUnreadCount(Long guardianId) {
+        return notificationRepository.countByGuardianIdAndReadYN(guardianId, "N");
     }
 
     @Transactional

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,2 @@
 spring.application.name=iKong-server
-# dev(supabase) ↔ main(oracle) 으로만 바꾸면 전환 완료
 spring.profiles.active=dev

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.application.name=iKong-server
 # dev(supabase) ↔ main(oracle) 으로만 바꾸면 전환 완료
-spring.profiles.active=dev
+spring.profiles.active=main

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,3 @@
 spring.application.name=iKong-server
 # dev(supabase) ↔ main(oracle) 으로만 바꾸면 전환 완료
-spring.profiles.active=main
+spring.profiles.active=dev


### PR DESCRIPTION

## 작업 내용

### NotificationService / NotificationController
- 알림 목록 조회 — 이름, 이벤트 유형, 상태 반환 / 보호자·피보호자 역할에 따라 자동 분기
- 읽지 않은 알림 수 조회
- 알림 읽음 처리

### EmergencyEventService / EmergencyEventController
- 해결건/미해결건 수 요약 조회
- 긴급 알림 목록 조회 — 이름, 이벤트 유형, 발생 시각, 상세 설명 반환
- 개별 이벤트 해결 처리 — 담당 피보호자 여부 권한 검증 포함
- 전체 미해결 이벤트 일괄 해결

### GuardianService / GuardianInvitation
- 보호자 초대 수락/거절 처리
- 이미 처리된 초대를 중복으로 수락/거절하는 버그 수정

### dev 브랜치 머지 충돌 해결
- `EmergencyEventService` — dev의 권한 검증 로직 + 기존 구현 메서드 병합
- `EmergencyEventController` — 중복 엔드포인트 제거 및 통합
- `EmergencyEventRepository` — 양측 쿼리 메서드 모두 유지
- `SecurityConfig` — 양측 requestMatcher 인증 규칙 통합

## 테스트
- **Thunder Client로 API 테스트 확인**

## 기타
- **자기가 맡은 담당 코드에 기능 설명 주석 추가**
