### PR TITLE
feat:긴급알림디테일및 피보호자 생체 데이터 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '4.0.5'
+    id 'org.springframework.boot' version '3.3.2'
     id 'io.spring.dependency-management' version '1.1.7'
 }
 
@@ -25,21 +25,24 @@ repositories {
 }
 
 dependencies {
+    // 기본 웹, JPA, 롬복
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client'
-    implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    // DB 드라이버
     runtimeOnly 'com.oracle.database.jdbc:ojdbc11'
     runtimeOnly 'org.postgresql:postgresql'
-    annotationProcessor 'org.projectlombok:lombok'
+    // JWT
     implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
-    testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-security-oauth2-client-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
-    testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    // 시큐리티 및 OAuth2
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    // 테스트
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/com/ikongserver/controller/EmergencyEventController.java
+++ b/src/main/java/com/ikongserver/controller/EmergencyEventController.java
@@ -3,7 +3,9 @@ package com.ikongserver.controller;
 import com.ikongserver.dto.EventDto.EmergencyAlertListResponse;
 import com.ikongserver.dto.EventDto.EventSummaryResponse;
 import com.ikongserver.dto.EventDto.ResponseEvent;
+import com.ikongserver.dto.NotificationDto.EmergencyEventDetailResponse;
 import com.ikongserver.service.EmergencyEventService;
+import com.ikongserver.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,9 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
- * 응급 이벤트 API 컨트롤러
- * - 피보호자 앱: 본인의 미해결 이벤트 조회
- * - 보호자 앱: 이벤트 요약, 목록 조회, 해결 처리
+ * 응급 이벤트 API 컨트롤러 - 피보호자 앱: 본인의 미해결 이벤트 조회 - 보호자 앱: 이벤트 요약, 목록 조회, 해결 처리
  */
 @RestController
 @RequiredArgsConstructor
@@ -25,6 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class EmergencyEventController {
 
     private final EmergencyEventService emergencyEventService;
+    private final NotificationService notificationService;
 
     // [피보호자용] 본인의 가장 최근 미처리(PENDING) 응급 이벤트 1건 반환 — 앱 화면에 팝업 표시용
     @GetMapping("{userId}/emergency")
@@ -66,4 +67,18 @@ public class EmergencyEventController {
         emergencyEventService.resolveAllEvents(guardianId);
         return ResponseEntity.ok().build();
     }
+
+    // [보호자용] 긴급 알림 디테일 상황
+    @GetMapping("{eventId}/detail")
+    public ResponseEntity<EmergencyEventDetailResponse> getEmergencyEventDetail(
+        @PathVariable Long eventId,
+        @AuthenticationPrincipal UserDetails userDetails) {
+        Long guardianId = Long.parseLong(userDetails.getUsername());
+        // 긴급 알림 디테일 데이터
+        EmergencyEventDetailResponse response = notificationService.getEmergencyEventDetail(eventId,
+            guardianId);
+        // 200 OK와 함께 DTO 반환
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/java/com/ikongserver/controller/UsersDetailController.java
+++ b/src/main/java/com/ikongserver/controller/UsersDetailController.java
@@ -1,0 +1,45 @@
+package com.ikongserver.controller;
+
+import com.ikongserver.dto.UserDto.UserStateDetailResponse;
+import com.ikongserver.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/guardians/me/users")
+public class UsersDetailController {
+
+    private final UserService userService;
+
+    // 보호자 화면에서 피보호자 생체 데이터 확인
+    @GetMapping("/{userId}/detail")
+    public ResponseEntity<UserStateDetailResponse> getUserProfileDetail(@PathVariable Long userId) {
+        // JWT 토큰의 subject에 guardianId가 들어있으므로 getName()으로 꺼내서 Long으로 변환
+        Long guardianId = currentGuardianId(); // 팀원분이 짠 방식 그대로 활용!
+        UserStateDetailResponse response = userService.getUserProfileDetail(userId, guardianId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 보호자Id 토큰으로 부터 가져오기
+    private Long currentGuardianId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getName() == null) {
+            throw new IllegalStateException("인증 정보가 없습니다.");
+        }
+        try {
+            return Long.parseLong(auth.getName());
+        } catch (NumberFormatException e) {
+            throw new IllegalStateException("유효하지 않은 토큰입니다.");
+        }
+    }
+
+
+
+}

--- a/src/main/java/com/ikongserver/controller/VitalController.java
+++ b/src/main/java/com/ikongserver/controller/VitalController.java
@@ -22,6 +22,8 @@ public class VitalController {
     private final VitalService vitalService;
     private final SseService sseService; // 프론트엔드로 데이터를 쏴줄 파이프 관리자
 
+    // todo:데이터 파이프라인(안정화 ➡️ SSE ➡️ 긴급검사 ➡️ 저장)
+
     // 라즈베리파이에서 서버로 데이터 넣기
     @PostMapping
     public ResponseEntity<String> receiveVitalData(@RequestBody VitalRequestDto vitalDto){

--- a/src/main/java/com/ikongserver/dto/EventDto.java
+++ b/src/main/java/com/ikongserver/dto/EventDto.java
@@ -7,7 +7,7 @@ public class EventDto {
 
     // 낙상 감지
     public record ResponseEvent(Long id, String eventType, String status,
-                                    LocalDateTime createdAt) {
+                                LocalDateTime createdAt) {
 
     }
 
@@ -30,7 +30,11 @@ public class EventDto {
         String status,
         LocalDateTime createdAt,
         String detail
-    ) {}
+    ) {
 
-    public record EmergencyAlertListResponse(List<EmergencyAlertResponse> alerts) {}
+    }
+
+    public record EmergencyAlertListResponse(List<EmergencyAlertResponse> alerts) {
+
+    }
 }

--- a/src/main/java/com/ikongserver/dto/NotificationDto.java
+++ b/src/main/java/com/ikongserver/dto/NotificationDto.java
@@ -5,11 +5,30 @@ import java.util.List;
 
 public class NotificationDto {
 
-    public record CreateNotificationRequest(Long eventId, Long guardianId, String message, String status) {}
+    public record CreateNotificationRequest(Long eventId, Long guardianId, String message,
+                                            String status) {
 
-    public record CreateNotificationResponse(Long notificationId, String message, LocalDateTime sentAt) {}
+    }
 
-    public record NotificationItem(Long notificationId, String userName, String eventType, String message, String status, LocalDateTime sentAt, String readYN) {}
+    public record CreateNotificationResponse(Long notificationId, String message,
+                                             LocalDateTime sentAt) {
 
-    public record NotificationListResponse(long total, List<NotificationItem> notifications) {}
+    }
+
+    public record NotificationItem(Long notificationId, String userName, String eventType,
+                                   String message, String status, LocalDateTime sentAt,
+                                   String readYN) {
+
+    }
+
+    public record NotificationListResponse(long total, List<NotificationItem> notifications) {
+
+    }
+
+    // 긴급 알림 디테일 (이름, event 유형, 상세 내용, 발생 시각)
+    public record EmergencyEventDetailResponse(Long userId, String name, Long eventId,
+                                               String eventType,
+                                               String description, LocalDateTime occurredAt) {
+
+    }
 }

--- a/src/main/java/com/ikongserver/dto/UserDto.java
+++ b/src/main/java/com/ikongserver/dto/UserDto.java
@@ -1,5 +1,7 @@
 package com.ikongserver.dto;
 
+import java.time.LocalDateTime;
+
 public class UserDto {
 
     // 피보호자 (이름, 수치(정상, 비정상, 이상))
@@ -7,5 +9,12 @@ public class UserDto {
 
     }
 
+    // 보호자 화면에서의 피보호자 상태 디테일 (이름, 관계, 상태, 실시간 생체 데이터(심박수, 호흡수, 최근 업데이트 시간), 활동 상태 (수면, 낙상, 활동 중))
+    public record UserStateDetailResponse(Long userId, String name, String relationship,
+                                          String overallStatus, int heartRate,
+                                          int breathRate, LocalDateTime updatedAt,
+                                          boolean activityStatus) {
+
+    }
 
 }

--- a/src/main/java/com/ikongserver/entity/EmergencyEvent.java
+++ b/src/main/java/com/ikongserver/entity/EmergencyEvent.java
@@ -47,6 +47,15 @@ public class EmergencyEvent {
         this.status = status;
     }
 
+    public String getEventDescription() {
+        return switch (this.eventType) {
+            case "FALL" -> "낙상이 감지되었습니다.";
+            case "HEART_ISSUE" -> "심박수 이상이 감지되었습니다.";
+            case "BREATH_ISSUE" -> "호흡수 이상이 감지되었습니다.";
+            default -> "이상이 감지되었습니다.";
+        };
+    }
+
     @Builder
     public EmergencyEvent(Users user, Device device,String eventType, String status) {
         this.user = user;

--- a/src/main/java/com/ikongserver/entity/HealthStatus.java
+++ b/src/main/java/com/ikongserver/entity/HealthStatus.java
@@ -32,18 +32,24 @@ public class HealthStatus {
     private LocalDate statDate;
 
     private int avgHeartRate;
+    private int minHeartRate;
+    private int maxHeartRate;
+    private int avgBreathRate;
     private int movementCount;
     private double sleepHours;
 
     @Builder
-    public HealthStatus(Users user, LocalDate statDate, int avgHeartRate, int movementCount,
-        int sleepHours) {
+    public HealthStatus(Users user, LocalDate statDate, int avgHeartRate,
+        int minHeartRate, int maxHeartRate, int avgBreathRate,
+        int movementCount, double sleepHours) {
         this.user = user;
         this.statDate = statDate;
         this.avgHeartRate = avgHeartRate;
+        this.minHeartRate = minHeartRate;
+        this.maxHeartRate = maxHeartRate;
+        this.avgBreathRate = avgBreathRate;
         this.movementCount = movementCount;
         this.sleepHours = sleepHours;
     }
-
 
 }

--- a/src/main/java/com/ikongserver/entity/Vital.java
+++ b/src/main/java/com/ikongserver/entity/Vital.java
@@ -47,6 +47,13 @@ public class Vital {
     @Column(updatable = false)
     private LocalDateTime recordedAt;
 
+    public boolean isHeartBreathNormal() {
+        boolean isHeartNormal = (this.heartRate >= 60 && this.heartRate <= 120);
+        boolean isBreathNormal = (this.breathRate >= 10 && this.breathRate <= 30);
+
+        return isHeartNormal && isBreathNormal;
+    }
+
 
     @Builder
     public Vital(Users user, Device device, int heartRate, int breathRate, boolean isFallDetected,
@@ -55,8 +62,8 @@ public class Vital {
         this.device = device;
         this.heartRate = heartRate;
         this.breathRate = breathRate;
-        this.isFallDetected = isFallDetected;
-        this.isPresent = isPresent;
+        this.isFallDetected = isFallDetected; // 낙상 감지
+        this.isPresent = isPresent; // 활동 상태
     }
 
 }

--- a/src/main/java/com/ikongserver/repository/EmergencyEventRepository.java
+++ b/src/main/java/com/ikongserver/repository/EmergencyEventRepository.java
@@ -25,4 +25,6 @@ public interface EmergencyEventRepository extends JpaRepository<EmergencyEvent, 
 
     // 단일 사용자의 상태별 이벤트 수 집계
     long countByUserAndStatus(Users user, String status);
+
+    Optional<EmergencyEvent> findById(Long eventId);
 }

--- a/src/main/java/com/ikongserver/repository/UserGuardianMapRepository.java
+++ b/src/main/java/com/ikongserver/repository/UserGuardianMapRepository.java
@@ -4,6 +4,7 @@ import com.ikongserver.entity.Guardian;
 import com.ikongserver.entity.UserGuardianMap;
 import com.ikongserver.entity.Users;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserGuardianMapRepository extends JpaRepository<UserGuardianMap, Long> {
@@ -18,4 +19,12 @@ public interface UserGuardianMapRepository extends JpaRepository<UserGuardianMap
 
     // 보호자가 담당하는 활성 피보호자 매핑 목록
     List<UserGuardianMap> findByGuardianAndIsActive(Guardian guardian, String isActive);
+
+    // 보호자 피보호자 연동 판별
+    Optional<UserGuardianMap> findByUserIdAndGuardianId(Long userId, Long guardianId);
+    boolean existsByUserIdAndGuardianId(Long userId, Long guardianId);
+
+    // 피보호자 보호자 관계
+    String findByUserId (Long userId);
+
 }

--- a/src/main/java/com/ikongserver/repository/VitalRepository.java
+++ b/src/main/java/com/ikongserver/repository/VitalRepository.java
@@ -2,6 +2,7 @@ package com.ikongserver.repository;
 
 import com.ikongserver.entity.Vital;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,4 +20,6 @@ public interface VitalRepository extends JpaRepository<Vital, Long> {
         ORDER BY v.device_id, v.recorded_at DESC
         """, nativeQuery = true)
     List<Vital> findLatestVitalPerDevice(@Param("userId") Long userId);
+
+    Optional<Vital> findFirstByUserIdOrderByRecordedAtDesc(Long userId);
 }

--- a/src/main/java/com/ikongserver/service/EmergencyEventService.java
+++ b/src/main/java/com/ikongserver/service/EmergencyEventService.java
@@ -110,9 +110,8 @@ public class EmergencyEventService {
                 event.getEventType(),
                 event.getStatus(),
                 event.getCreatedAt(),
-                toDetail(event.getEventType())
-            ))
-            .toList();
+                event.getEventDescription())
+            ).toList();
 
         return new EmergencyAlertListResponse(alerts);
     }
@@ -155,15 +154,6 @@ public class EmergencyEventService {
 
         emergencyEventRepository.findByUserInAndStatus(users, "PENDING")
             .forEach(event -> event.updateStatus("RESOLVED"));
-    }
-
-    private String toDetail(String eventType) {
-        return switch (eventType) {
-            case "FALL" -> "낙상이 감지되었습니다.";
-            case "HEART_ISSUE" -> "심박수 이상이 감지되었습니다.";
-            case "BREATH_ISSUE" -> "호흡수 이상이 감지되었습니다.";
-            default -> "이상이 감지되었습니다.";
-        };
     }
 
     // 피보호자 ID로 가장 최근 PENDING 이벤트 1건 조회 — 없으면 null 반환 (앱 팝업 표시 여부 판단용)

--- a/src/main/java/com/ikongserver/service/NotificationService.java
+++ b/src/main/java/com/ikongserver/service/NotificationService.java
@@ -2,14 +2,19 @@ package com.ikongserver.service;
 
 import com.ikongserver.dto.NotificationDto.CreateNotificationRequest;
 import com.ikongserver.dto.NotificationDto.CreateNotificationResponse;
+import com.ikongserver.dto.NotificationDto.EmergencyEventDetailResponse;
 import com.ikongserver.dto.NotificationDto.NotificationItem;
 import com.ikongserver.dto.NotificationDto.NotificationListResponse;
 import com.ikongserver.entity.EmergencyEvent;
 import com.ikongserver.entity.Guardian;
 import com.ikongserver.entity.Notification;
+import com.ikongserver.entity.UserGuardianMap;
+import com.ikongserver.entity.Users;
 import com.ikongserver.repository.EmergencyEventRepository;
 import com.ikongserver.repository.GuardianRepository;
 import com.ikongserver.repository.NotificationRepository;
+import com.ikongserver.repository.UserGuardianMapRepository;
+import com.ikongserver.repository.UsersRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -23,81 +28,86 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final EmergencyEventRepository emergencyEventRepository;
     private final GuardianRepository guardianRepository;
+    private final UserGuardianMapRepository userGuardianMapRepository;
+    private final UsersRepository userRepository;
 
     // 응급 이벤트와 연결된 알림 생성 — status 미입력 시 기본값 "SUCCESS" 저장
     @Transactional
     public CreateNotificationResponse createNotification(CreateNotificationRequest request) {
         EmergencyEvent event = emergencyEventRepository.findById(request.eventId())
-                .orElseThrow(() -> new RuntimeException("비상 이벤트를 찾을 수 없습니다."));
+            .orElseThrow(() -> new RuntimeException("비상 이벤트를 찾을 수 없습니다."));
 
         Guardian guardian = guardianRepository.findById(request.guardianId())
-                .orElseThrow(() -> new RuntimeException("보호자를 찾을 수 없습니다."));
+            .orElseThrow(() -> new RuntimeException("보호자를 찾을 수 없습니다."));
 
         Notification notification = notificationRepository.save(
-                Notification.builder()
-                        .emergencyEvent(event)
-                        .guardian(guardian)
-                        .message(request.message())
-                        .status(request.status() != null ? request.status() : "SUCCESS")
-                        .build()
+            Notification.builder()
+                .emergencyEvent(event)
+                .guardian(guardian)
+                .message(request.message())
+                .status(request.status() != null ? request.status() : "SUCCESS")
+                .build()
         );
 
-        return new CreateNotificationResponse(notification.getId(), notification.getMessage(), notification.getSentAt());
+        return new CreateNotificationResponse(notification.getId(), notification.getMessage(),
+            notification.getSentAt());
     }
 
     // 보호자 ID 기준 알림 목록 조회 — status 파라미터가 있으면 상태 필터 적용, 없으면 전체 반환 (페이징)
     @Transactional(readOnly = true)
-    public NotificationListResponse getNotifications(Long guardianId, String status, int page, int size) {
+    public NotificationListResponse getNotifications(Long guardianId, String status, int page,
+        int size) {
         Page<Notification> result;
 
         if (status != null && !status.isEmpty()) {
             result = notificationRepository.findByGuardianIdAndStatus(
-                    guardianId, status, PageRequest.of(page - 1, size));
+                guardianId, status, PageRequest.of(page - 1, size));
         } else {
             result = notificationRepository.findByGuardianId(
-                    guardianId, PageRequest.of(page - 1, size));
+                guardianId, PageRequest.of(page - 1, size));
         }
 
         return new NotificationListResponse(
-                result.getTotalElements(),
-                result.getContent().stream()
-                        .map(n -> new NotificationItem(
-                                n.getId(),
-                                n.getEmergencyEvent().getUser().getName(),
-                                n.getEmergencyEvent().getEventType(),
-                                n.getMessage(),
-                                n.getStatus(),
-                                n.getSentAt(),
-                                n.getReadYN()))
-                        .toList()
+            result.getTotalElements(),
+            result.getContent().stream()
+                .map(n -> new NotificationItem(
+                    n.getId(),
+                    n.getEmergencyEvent().getUser().getName(),
+                    n.getEmergencyEvent().getEventType(),
+                    n.getMessage(),
+                    n.getStatus(),
+                    n.getSentAt(),
+                    n.getReadYN()))
+                .toList()
         );
     }
 
     // 피보호자 ID 기준 알림 목록 조회 — 본인과 연결된 응급 이벤트의 알림만 반환 (페이징)
     @Transactional(readOnly = true)
-    public NotificationListResponse getNotificationsByUserId(Long userId, String status, int page, int size) {
+    public NotificationListResponse getNotificationsByUserId(Long userId, String status, int page,
+        int size) {
         Page<Notification> result;
 
         if (status != null && !status.isEmpty()) {
             result = notificationRepository.findByUserIdAndStatus(
-                    userId, status, PageRequest.of(page - 1, size));
+                userId, status, PageRequest.of(page - 1, size));
         } else {
             result = notificationRepository.findByUserId(
-                    userId, PageRequest.of(page - 1, size));
+                userId, PageRequest.of(page - 1, size));
         }
 
         return new NotificationListResponse(
-                result.getTotalElements(),
-                result.getContent().stream()
-                        .map(n -> new NotificationItem(
-                                n.getId(),
-                                n.getEmergencyEvent().getUser().getName(),
-                                n.getEmergencyEvent().getEventType(),
-                                n.getMessage(),
-                                n.getStatus(),
-                                n.getSentAt(),
-                                n.getReadYN()))
-                        .toList()
+            result.getTotalElements(),
+            result.getContent().stream()
+                .map(n -> new NotificationItem(
+                    n.getId(),
+                    n.getEmergencyEvent().getUser().getName(),
+                    n.getEmergencyEvent().getEventType(),
+                    n.getMessage(),
+                    n.getStatus(),
+                    n.getSentAt(),
+                    n.getReadYN()))
+                .toList()
         );
     }
 
@@ -110,7 +120,32 @@ public class NotificationService {
     @Transactional
     public void markAsRead(Long notificationId) {
         Notification notification = notificationRepository.findById(notificationId)
-                .orElseThrow(() -> new RuntimeException("알림을 찾을 수 없습니다."));
+            .orElseThrow(() -> new RuntimeException("알림을 찾을 수 없습니다."));
         notification.updateReadYN("Y");
+    }
+
+    // 긴급 알림 디테일 상황
+    @Transactional(readOnly = true)
+    public EmergencyEventDetailResponse getEmergencyEventDetail(Long eventId, Long guardianId) {
+
+        // 긴급 알림 내역 가져오기
+        EmergencyEvent event = emergencyEventRepository.findById(eventId)
+            .orElseThrow(() -> new RuntimeException("긴급 event를 불러오기를 실패했습니다."));
+
+        // 긴급 알림에서 피보호자 꺼내기
+        Users user = event.getUser();
+
+        // 관계 검증
+        if (!userGuardianMapRepository.existsByUserIdAndGuardianId(user.getId(), guardianId)) {
+            throw new IllegalArgumentException("해당 알림을 볼 권한이 없습니다.");
+        }
+
+        String eventType = event.getEventType();
+
+        // 상세 설명
+        String description = event.getEventDescription();
+
+        return new EmergencyEventDetailResponse(user.getId(), user.getName(), eventId,
+            event.getEventType(), description, event.getCreatedAt());
     }
 }

--- a/src/main/java/com/ikongserver/service/UserService.java
+++ b/src/main/java/com/ikongserver/service/UserService.java
@@ -1,9 +1,14 @@
 package com.ikongserver.service;
 
 import com.ikongserver.dto.UserDto.MainProfileResponse;
+import com.ikongserver.dto.UserDto.UserStateDetailResponse;
+import com.ikongserver.entity.UserGuardianMap;
 import com.ikongserver.entity.Users;
+import com.ikongserver.entity.Vital;
 import com.ikongserver.repository.EmergencyEventRepository;
+import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
+import com.ikongserver.repository.VitalRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +20,8 @@ public class UserService {
 
     private final UsersRepository userRepository;
     private final EmergencyEventRepository emergencyEventRepository;
+    private final UserGuardianMapRepository userGuardianMapRepository;
+    private final VitalRepository vitalRepository;
 
     public MainProfileResponse getMainProfile(Long userId) {
 
@@ -32,5 +39,40 @@ public class UserService {
             user.getName(),
             currentStatus
         );
+    }
+
+    @Transactional(readOnly = true)
+    public UserStateDetailResponse getUserProfileDetail(Long userId, Long guardianId) {
+
+        // 관계 검증
+        UserGuardianMap isLinked = userGuardianMapRepository.findByUserIdAndGuardianId(userId,
+            guardianId).orElseThrow(() -> new RuntimeException("권한이 없는 피보호자 입니다."));
+
+        // 피보호자 정보 가져오기
+        Users user = isLinked.getUser();
+
+        // 최근 생체 정보 가져오기
+        Vital latestVital = vitalRepository.findFirstByUserIdOrderByRecordedAtDesc(userId)
+            .orElse(null);
+
+        // 심장, 호흡 값 확인 true(정상), false(긴급)
+        boolean heartBreathRateCheck = true;
+        // 낙상 값 확인
+        boolean activityStatus = true;
+
+        if (latestVital != null) {
+            // Vital 정상값 비정상값 판별
+            heartBreathRateCheck = latestVital.isHeartBreathNormal();
+            // 낙상 감지가 true(발생)면, activityStatus(활동상태)는 false(비정상)가 됩니다.
+            activityStatus = !latestVital.isFallDetected();
+        }
+
+        String overallStatus = (heartBreathRateCheck && activityStatus) ? "정상" : "긴급";
+
+        // dto로 변환
+        return new UserStateDetailResponse(user.getId(), user.getName(), isLinked.getRelation(),
+            overallStatus, latestVital != null ? latestVital.getHeartRate() : 0,
+            latestVital != null ? latestVital.getBreathRate() : 0,
+            latestVital != null ? latestVital.getRecordedAt() : null, activityStatus);
     }
 }


### PR DESCRIPTION
1. 긴급 알림 상세 조회 API 구현 (/api/emergency_event/{eventId}/detail)
보안 및 권한 검증: JWT 토큰의 AuthenticationPrincipal을 활용해 현재 로그인한 보호자가 해당 피보호자의 알림을 볼 권한이 있는지 UserGuardianMap을 통해 검증합니다.

상세 정보 제공: 유저 정보, 이벤트 타입, 발생 시간, 그리고 상황에 맞는 한글 상세 설명을 반환합니다.

2. 도메인 모델 중심의 로직 설계 (OOP 적용)
상세 설명 로직의 엔티티 응집: 서비스 계층에 흩어져 있던 "이벤트 타입별 한글 설명" 변환 로직을 EmergencyEvent 엔티티 내부 메서드(getEventDescription)로 이동시켰습니다.

데이터 조회 최적화: UserGuardianMap 엔티티에 연관된 Users 객체를 활용하여, 불필요하게 DB를 다시 조회하는 쿼리를 제거하고 성능을 개선했습니다.

3. 실시간 데이터 정렬 및 조회 로직 개선
최신성 보장: 피보호자의 프로필 상세 조회 시, recordedAt 기준 내림차순 정렬(OrderByRecordedAtDesc)을 적용하여 가장 최근의 생체 수치를 정확히 반환하도록 구현했습니다.

🛠️ 트러블슈팅 (Troubleshooting)
API 경로 매핑 오류 수정: 컨트롤러의 클래스 레벨 주소와 메서드 레벨 주소가 합쳐지는 과정에서 발생했던 URL 경로 누락 문제를 해결했습니다. (최종 주소: /api/emergency_event/{eventId}/detail)

데이터 정렬 확인: DB GUI 툴의 페이징(Pagination)으로 인해 최신 데이터가 보이지 않던 현상을 쿼리 레벨의 정렬 조건을 통해 서버 로직에서 해결했음을 확인했습니다.