### PR TITLE
feat:VitalService에 데이터 안정화 작업 및 10초마다 한 번 저장하기

### DIFF
--- a/src/main/java/com/ikongserver/controller/VitalController.java
+++ b/src/main/java/com/ikongserver/controller/VitalController.java
@@ -26,7 +26,7 @@ public class VitalController {
 
     // 라즈베리파이에서 서버로 데이터 넣기
     @PostMapping
-    public ResponseEntity<String> receiveVitalData(@RequestBody VitalRequestDto vitalDto){
+    public ResponseEntity<String> receiveVitalData(@RequestBody VitalRequestDto vitalDto) {
 
         vitalService.getVitalData(vitalDto);
         return ResponseEntity.ok("데이터 수신 및 처리 완료");

--- a/src/main/java/com/ikongserver/dto/VitalDto.java
+++ b/src/main/java/com/ikongserver/dto/VitalDto.java
@@ -5,7 +5,7 @@ public class VitalDto {
     // 실시간 심박 및 호흡
     // int는 값이 없을 때 0 이고 Integer은 값이 없을 때 NULL을 넣을 수 있음
     // status는 실시간으로 피보호자의 상태 확인
-    public record ResponseUserVital(Long id, Integer heartRate, Integer breathRate, String status) {
+    public record ResponseUserVital(Long id, Integer heartRate, Integer breathRate, boolean status) {
 
     }
 
@@ -18,4 +18,5 @@ public class VitalDto {
         boolean isPresent) {
 
     }
+
 }

--- a/src/main/java/com/ikongserver/entity/Vital.java
+++ b/src/main/java/com/ikongserver/entity/Vital.java
@@ -63,7 +63,7 @@ public class Vital {
         this.heartRate = heartRate;
         this.breathRate = breathRate;
         this.isFallDetected = isFallDetected; // 낙상 감지
-        this.isPresent = isPresent; // 활동 상태
+        this.isPresent =  isPresent;
     }
 
 }

--- a/src/main/java/com/ikongserver/service/VitalService.java
+++ b/src/main/java/com/ikongserver/service/VitalService.java
@@ -7,6 +7,8 @@ import com.ikongserver.entity.Users;
 import com.ikongserver.entity.Vital;
 import com.ikongserver.repository.DeviceRepository;
 import com.ikongserver.repository.VitalRepository;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,45 +23,64 @@ public class VitalService {
     private final SseService sseService;
 
     // 라즈베리파이에서 데이터 받아오기
-    // 라즈베리 파이 예상 데이터 구조
-    /*
-    payload = {
-        "serialNum": "RPI-TEST-01",
-        "heartRate": 85,
-        "breathRate": 18,
-        "isFallDetected": False,  # 파이썬은 대문자 False/True 입니다
-        "isPresent": True
-    }
-    */
+    // 기기별로 마지막으로 Vital 데이터를 저장한 시간을 기록하는 메모리 맵
+    // Key: 기기 시리얼 넘버, Value: 마지막 저장 시간(Timestamp)
+    private final Map<String, Long> lastSavedTimeMap = new ConcurrentHashMap<>();
 
     @Transactional
     public void getVitalData(VitalRequestDto vitalDto) {
-
         // 라즈베리와 연결이 되어 있는지 확인
         Device device = deviceRepository.findBySerialNum(vitalDto.serialNum())
             .orElseThrow(() -> new IllegalArgumentException("기기를 찾을 수 없습니다."));
-
         // 매초 마다 업데이트 되는 데이터를 device 테이블 안에서는 1분마다 연결 되어 있다는 마지막 연결 시간을 업데이트 함.
         device.updateLastConnectedAt();
 
+        // 디바이스에서 피보호자 객체 찾기
         Users user = device.getUser();
 
+        // 데이터 안정화 (알고리즘 필터 통과)
+        int stabilizedHR = filterNoise_HR(vitalDto.heartRate());
+        int stabilizedBR = filterNoise_BR(vitalDto.breathRate());
+
+        // 긴급 상황 검사 및 상태 반환
+        boolean status = false;
+        boolean isFallEvent = emergencyEventService.checkFallEvent(vitalDto, user, device);
+        boolean isHREvent = emergencyEventService.checkHeartBreathEvent(vitalDto, user, device);
+
+        if (isFallEvent || isHREvent) {
+            status = true;
+        }
+
+        // 프론트엔드로 실시간 SSE 전송
+        ResponseUserVital sseData = new ResponseUserVital(user.getId(), stabilizedHR, stabilizedBR,
+            status);
+        sseService.sendVitalDataToClient(user.getId(), sseData);
+
+        long currentTime = System.currentTimeMillis();
+        long lastSavedTime = lastSavedTimeMap.getOrDefault(vitalDto.serialNum(), 0L);
+
         // 받은 데이터를 Vital 테이블에 저장
-        Vital newVital = Vital.builder()
-            .user(user)
-            .device(device)
-            .heartRate(vitalDto.heartRate())
-            .breathRate(vitalDto.breathRate())
-            .isPresent(vitalDto.isPresent())
-            .build();
-        vitalRepository.save(newVital);
-
-        // 라즈베리파이에서 받은 데이터 낙상검사 및 심박수, 호흡수 검사
-        // 이벤트 발생시 EmergencyEvent 서비스에서 db에 저장
-        emergencyEventService.checkFallEvent(vitalDto, user, device);
-        emergencyEventService.checkHeartBreathEvent(vitalDto, user, device);
-
-        // 찾은 주인의 아이디(Long)로 SSE 알림
-        sseService.sendVitalDataToClient(user.getId(), vitalDto);
+        if (currentTime - lastSavedTime >= 10000) {
+            Vital newVital = Vital.builder()
+                .user(user)
+                .device(device)
+                .heartRate(stabilizedHR)
+                .breathRate(stabilizedBR)
+                .isFallDetected(status)
+                .isPresent(vitalDto.isPresent())
+                .build();
+            vitalRepository.save(newVital);
+            lastSavedTimeMap.put(vitalDto.serialNum(), currentTime);
+        }
     }
+
+    // --- 데이터 안정화 알고리즘 더미 (추후 로직 채워넣을 예정) ---
+    private int filterNoise_HR(int rawHeartRate) {
+        return rawHeartRate; // 일단 들어온 값 그대로 반환
+    }
+
+    private int filterNoise_BR(int rawBreathRate) {
+        return rawBreathRate; // 일단 들어온 값 그대로 반환
+    }
+
 }


### PR DESCRIPTION
🚀 Pull Request: 실시간 생체 데이터 파이프라인 구축 및 DB 최적화 (10초 샘플링)
📝 개요 (Summary)
라즈베리파이 센서로부터 1초 단위로 유입되는 대량의 생체 데이터를 효율적으로 처리하기 위해 VitalService에 3-Track 데이터 파이프라인을 구축했습니다.
특히, 사용자 증가에 따른 DB I/O 과부하를 방지하기 위해 실시간 데이터는 SSE로 즉시 전송하되, DB 저장은 10초 단위로 샘플링하여 기록하도록 아키텍처를 최적화했습니다.

✨ 핵심 변경 사항 (Key Changes)
1. 3-Track 데이터 처리 파이프라인 도입
기존의 단순 저장 로직을 역할에 따라 세 갈래로 분리하여 VitalService.getVitalData()에서 총괄하도록 개선했습니다.

Track A (실시간 모니터링): 1초마다 들어오는 데이터는 프론트엔드 실시간 렌더링을 위해 가공 후 즉시 SseService로 전송.

Track B (긴급 이벤트 즉시 처리): 낙상 감지(isFallDetected) 또는 심박/호흡 비정상 수치 발생 시, 즉각적으로 EmergencyEvent를 생성하여 증거 데이터 보존 및 알림 발생.

Track C (DB 부하 최적화 - 샘플링 저장): 무거운 DB I/O를 방지하기 위해 Vital 테이블에는 10초 주기로 1개의 데이터만 솎아내어(Sampling) 저장.

2. 동시성을 고려한 기기별 초시계(Map) 구현
10초 샘플링 로직 적용 시, 여러 기기에서 동시에 데이터가 들어올 때 발생할 수 있는 동시성 문제(타이머 꼬임 현상)를 해결했습니다.

ConcurrentHashMap 기반의 lastSavedTimeMap을 도입하여, 기기 시리얼 번호(serialNum)별로 마지막 DB 저장 시간을 독립적으로 기록하고 체크하도록 구현했습니다.

3. 도메인 로직 및 타입 안정성 개선
긴급 상황 판별 시, 낙상과 생체 수치 이상 중 하나만 발생해도 위험 상태로 인지하도록 OR 연산자(||)를 적용했습니다.

외부 통신용 DTO(ResponseUserVital)와 내부 DB용 Entity(Vital)의 역할을 명확히 분리하고, 프론트엔드 스펙에 맞게 상태값을 매핑했습니다.

🛠️ 트러블슈팅 및 주요 고려 사항
상태 갱신 누락 방지: 10초 주기로 DB save() 수행 후, 반드시 lastSavedTimeMap.put()을 호출하여 타이머를 초기화하도록 상태 갱신 로직을 보완하여 무한 저장 루프(폭주)를 방지했습니다.

추후 과제: 현재 filterNoise_HR, filterNoise_BR 메서드 내부는 원본 값을 그대로 반환 중입니다. 다음 작업에서 이 부분에 '이동 평균(Moving Average)' 등의 데이터 안정화 알고리즘을 추가할 예정입니다.