### PR TITLE
feat: 피보호자 생체 통계 API 구현 (심박수/호흡수 그래프, 일/주/월 요약)

### DIFF
--- a/src/main/java/com/ikongserver/controller/UsersDetailController.java
+++ b/src/main/java/com/ikongserver/controller/UsersDetailController.java
@@ -1,5 +1,6 @@
 package com.ikongserver.controller;
 
+import com.ikongserver.dto.StatsDto.VitalStatsResponse;
 import com.ikongserver.dto.UserDto.UserStateDetailResponse;
 import com.ikongserver.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,16 +20,26 @@ public class UsersDetailController {
 
     private final UserService userService;
 
-    // 보호자 화면에서 피보호자 생체 데이터 확인
+    // 피보호자 생체 데이터 상태 상세 조회 (이름, 관계, 상태, 심박수, 호흡수, 업데이트 시간, 활동 상태)
     @GetMapping("/{userId}/detail")
     public ResponseEntity<UserStateDetailResponse> getUserProfileDetail(@PathVariable Long userId) {
-        // JWT 토큰의 subject에 guardianId가 들어있으므로 getName()으로 꺼내서 Long으로 변환
-        Long guardianId = currentGuardianId(); // 팀원분이 짠 방식 그대로 활용!
+        Long guardianId = currentGuardianId();
         UserStateDetailResponse response = userService.getUserProfileDetail(userId, guardianId);
         return ResponseEntity.ok(response);
     }
 
-    // 보호자Id 토큰으로 부터 가져오기
+    // 생체 통계 그래프 조회 — type(HEART/BREATH), period(TODAY/WEEK/MONTH)
+    // 응답: 평균/최소/최대 + 그래프 데이터(오름차순) + 하단 목록(내림차순)
+    @GetMapping("/{userId}/stats")
+    public ResponseEntity<VitalStatsResponse> getVitalStats(
+        @PathVariable Long userId,
+        @RequestParam(defaultValue = "HEART") String type,
+        @RequestParam(defaultValue = "TODAY") String period) {
+        Long guardianId = currentGuardianId();
+        return ResponseEntity.ok(userService.getVitalStats(userId, guardianId, type, period));
+    }
+
+    // JWT 토큰의 subject(guardianId)를 SecurityContext에서 추출
     private Long currentGuardianId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || auth.getName() == null) {

--- a/src/main/java/com/ikongserver/dto/StatsDto.java
+++ b/src/main/java/com/ikongserver/dto/StatsDto.java
@@ -1,5 +1,18 @@
 package com.ikongserver.dto;
 
+import java.util.List;
+
 public class StatsDto {
 
+    // 그래프 및 하단 목록의 단일 데이터 포인트 (label: "N시" 또는 "MM/DD", value: bpm)
+    public record GraphPoint(String label, int value) {}
+
+    // 생체 통계 응답 — 평균/최소/최대 + 그래프 데이터(오름차순) + 하단 목록(내림차순)
+    public record VitalStatsResponse(
+        int avg,
+        int min,
+        int max,
+        List<GraphPoint> graphData,   // 그래프 표시용 (오름차순)
+        List<GraphPoint> detailList   // 하단 시간별 목록 (내림차순)
+    ) {}
 }

--- a/src/main/java/com/ikongserver/repository/VitalRepository.java
+++ b/src/main/java/com/ikongserver/repository/VitalRepository.java
@@ -9,10 +9,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface VitalRepository extends JpaRepository<Vital, Long> {
 
-    /**
-     * 한 피보호자의 모든 디바이스에 대해 가장 최근 vital 1건씩 조회.
-     * PostgreSQL DISTINCT ON 사용으로 단일 쿼리로 처리.
-     */
+    // 피보호자의 모든 디바이스에 대해 가장 최근 vital 1건씩 조회 (PostgreSQL DISTINCT ON 사용)
     @Query(value = """
         SELECT DISTINCT ON (v.device_id) v.*
         FROM vital v
@@ -21,5 +18,92 @@ public interface VitalRepository extends JpaRepository<Vital, Long> {
         """, nativeQuery = true)
     List<Vital> findLatestVitalPerDevice(@Param("userId") Long userId);
 
+    // 피보호자의 가장 최근 vital 1건 조회
     Optional<Vital> findFirstByUserIdOrderByRecordedAtDesc(Long userId);
+
+    // [오늘] 시간별 심박수 평균/최소/최대 — 결과: [hour, avg, min, max]
+    @Query(value = """
+        SELECT EXTRACT(HOUR FROM recorded_at)::int AS hour,
+               ROUND(AVG(heart_rate))::int          AS avg_val,
+               MIN(heart_rate)                       AS min_val,
+               MAX(heart_rate)                       AS max_val
+        FROM vital
+        WHERE user_id = :userId
+          AND recorded_at >= CURRENT_DATE
+          AND recorded_at < CURRENT_DATE + INTERVAL '1 day'
+        GROUP BY EXTRACT(HOUR FROM recorded_at)
+        ORDER BY hour
+        """, nativeQuery = true)
+    List<Object[]> findHourlyHeartRateToday(@Param("userId") Long userId);
+
+    // [오늘] 시간별 호흡수 평균/최소/최대 — 결과: [hour, avg, min, max]
+    @Query(value = """
+        SELECT EXTRACT(HOUR FROM recorded_at)::int AS hour,
+               ROUND(AVG(breath_rate))::int         AS avg_val,
+               MIN(breath_rate)                      AS min_val,
+               MAX(breath_rate)                      AS max_val
+        FROM vital
+        WHERE user_id = :userId
+          AND recorded_at >= CURRENT_DATE
+          AND recorded_at < CURRENT_DATE + INTERVAL '1 day'
+        GROUP BY EXTRACT(HOUR FROM recorded_at)
+        ORDER BY hour
+        """, nativeQuery = true)
+    List<Object[]> findHourlyBreathRateToday(@Param("userId") Long userId);
+
+    // [이번 주] 일별 심박수 평균/최소/최대 — 결과: [label(MM/DD), avg, min, max]
+    @Query(value = """
+        SELECT TO_CHAR(recorded_at, 'MM/DD') AS label,
+               ROUND(AVG(heart_rate))::int   AS avg_val,
+               MIN(heart_rate)               AS min_val,
+               MAX(heart_rate)               AS max_val
+        FROM vital
+        WHERE user_id = :userId
+          AND recorded_at >= DATE_TRUNC('week', CURRENT_DATE)
+        GROUP BY DATE(recorded_at), TO_CHAR(recorded_at, 'MM/DD')
+        ORDER BY DATE(recorded_at)
+        """, nativeQuery = true)
+    List<Object[]> findDailyHeartRateThisWeek(@Param("userId") Long userId);
+
+    // [이번 주] 일별 호흡수 평균/최소/최대 — 결과: [label(MM/DD), avg, min, max]
+    @Query(value = """
+        SELECT TO_CHAR(recorded_at, 'MM/DD') AS label,
+               ROUND(AVG(breath_rate))::int  AS avg_val,
+               MIN(breath_rate)              AS min_val,
+               MAX(breath_rate)              AS max_val
+        FROM vital
+        WHERE user_id = :userId
+          AND recorded_at >= DATE_TRUNC('week', CURRENT_DATE)
+        GROUP BY DATE(recorded_at), TO_CHAR(recorded_at, 'MM/DD')
+        ORDER BY DATE(recorded_at)
+        """, nativeQuery = true)
+    List<Object[]> findDailyBreathRateThisWeek(@Param("userId") Long userId);
+
+    // [이번 달] 일별 심박수 평균/최소/최대 — 결과: [label(D일), avg, min, max]
+    @Query(value = """
+        SELECT TO_CHAR(recorded_at, 'DD일') AS label,
+               ROUND(AVG(heart_rate))::int  AS avg_val,
+               MIN(heart_rate)              AS min_val,
+               MAX(heart_rate)              AS max_val
+        FROM vital
+        WHERE user_id = :userId
+          AND recorded_at >= DATE_TRUNC('month', CURRENT_DATE)
+        GROUP BY DATE(recorded_at), TO_CHAR(recorded_at, 'DD일')
+        ORDER BY DATE(recorded_at)
+        """, nativeQuery = true)
+    List<Object[]> findDailyHeartRateThisMonth(@Param("userId") Long userId);
+
+    // [이번 달] 일별 호흡수 평균/최소/최대 — 결과: [label(D일), avg, min, max]
+    @Query(value = """
+        SELECT TO_CHAR(recorded_at, 'DD일') AS label,
+               ROUND(AVG(breath_rate))::int AS avg_val,
+               MIN(breath_rate)             AS min_val,
+               MAX(breath_rate)             AS max_val
+        FROM vital
+        WHERE user_id = :userId
+          AND recorded_at >= DATE_TRUNC('month', CURRENT_DATE)
+        GROUP BY DATE(recorded_at), TO_CHAR(recorded_at, 'DD일')
+        ORDER BY DATE(recorded_at)
+        """, nativeQuery = true)
+    List<Object[]> findDailyBreathRateThisMonth(@Param("userId") Long userId);
 }

--- a/src/main/java/com/ikongserver/service/UserService.java
+++ b/src/main/java/com/ikongserver/service/UserService.java
@@ -1,5 +1,7 @@
 package com.ikongserver.service;
 
+import com.ikongserver.dto.StatsDto.GraphPoint;
+import com.ikongserver.dto.StatsDto.VitalStatsResponse;
 import com.ikongserver.dto.UserDto.MainProfileResponse;
 import com.ikongserver.dto.UserDto.UserStateDetailResponse;
 import com.ikongserver.entity.UserGuardianMap;
@@ -9,6 +11,9 @@ import com.ikongserver.repository.EmergencyEventRepository;
 import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
 import com.ikongserver.repository.VitalRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -74,5 +79,59 @@ public class UserService {
             overallStatus, latestVital != null ? latestVital.getHeartRate() : 0,
             latestVital != null ? latestVital.getBreathRate() : 0,
             latestVital != null ? latestVital.getRecordedAt() : null, activityStatus);
+    }
+
+    // 생체 통계 조회 — type(HEART/BREATH) × period(TODAY/WEEK/MONTH) 조합으로 평균/최소/최대 및 그래프 데이터 반환
+    public VitalStatsResponse getVitalStats(Long userId, Long guardianId, String type, String period) {
+
+        // 보호자-피보호자 관계 검증
+        userGuardianMapRepository.findByUserIdAndGuardianId(userId, guardianId)
+            .orElseThrow(() -> new RuntimeException("권한이 없는 피보호자 입니다."));
+
+        // type과 period 조합으로 적절한 쿼리 선택
+        List<Object[]> rows = switch (type) {
+            case "HEART" -> switch (period) {
+                case "TODAY" -> vitalRepository.findHourlyHeartRateToday(userId);
+                case "WEEK"  -> vitalRepository.findDailyHeartRateThisWeek(userId);
+                case "MONTH" -> vitalRepository.findDailyHeartRateThisMonth(userId);
+                default -> throw new IllegalArgumentException("잘못된 period 값입니다: " + period);
+            };
+            case "BREATH" -> switch (period) {
+                case "TODAY" -> vitalRepository.findHourlyBreathRateToday(userId);
+                case "WEEK"  -> vitalRepository.findDailyBreathRateThisWeek(userId);
+                case "MONTH" -> vitalRepository.findDailyBreathRateThisMonth(userId);
+                default -> throw new IllegalArgumentException("잘못된 period 값입니다: " + period);
+            };
+            default -> throw new IllegalArgumentException("잘못된 type 값입니다: " + type);
+        };
+
+        // 데이터 없으면 빈 응답 반환
+        if (rows.isEmpty()) {
+            return new VitalStatsResponse(0, 0, 0, List.of(), List.of());
+        }
+
+        // 전체 평균/최소/최대 계산
+        int totalAvg = (int) rows.stream().mapToInt(r -> ((Number) r[1]).intValue()).average().orElse(0);
+        int totalMin = rows.stream().mapToInt(r -> ((Number) r[2]).intValue()).min().orElse(0);
+        int totalMax = rows.stream().mapToInt(r -> ((Number) r[3]).intValue()).max().orElse(0);
+
+        // 그래프 데이터 — 오름차순 (TODAY: "N시", WEEK/MONTH: "MM/DD" 또는 "D일")
+        List<GraphPoint> graphData = rows.stream()
+            .map(r -> new GraphPoint(formatLabel(r[0], period), ((Number) r[1]).intValue()))
+            .toList();
+
+        // 하단 목록 — 내림차순 (최신 시간이 위로)
+        List<GraphPoint> detailList = new ArrayList<>(graphData);
+        Collections.reverse(detailList);
+
+        return new VitalStatsResponse(totalAvg, totalMin, totalMax, graphData, detailList);
+    }
+
+    // TODAY: "N시" 포맷, WEEK/MONTH: 쿼리에서 이미 포맷된 문자열 그대로 사용
+    private String formatLabel(Object raw, String period) {
+        if ("TODAY".equals(period)) {
+            return ((Number) raw).intValue() + "시";
+        }
+        return raw.toString();
     }
 }


### PR DESCRIPTION
## 변경 사항
- 피보호자 생체 데이터 화면의 통계 그래프 API 부분을 구현했습니다.

## 작업 내용
- `StatsDto.java` — GraphPoint, VitalStatsResponse 레코드 정의
- `VitalRepository.java` — 심박수/호흡수 시간별·일별 통계 쿼리 6개 추가 (PostgreSQL 네이티브 쿼리)
- `UserService.java` — getVitalStats() 서비스 로직 구현 (type × period 조합 처리)
- `UsersDetailController.java` — GET /{userId}/stats 엔드포인트 추가

**지원 조합**
- type: `HEART` / `BREATH`
- period: `TODAY`(시간별) / `WEEK`(일별) / `MONTH`(일별)
- 응답: 전체 평균·최소·최대 + 그래프 데이터(오름차순) + 하단 목록(내림차순)

## 테스트
- Postman으로 직접 테스트 완료
