### PR TITLE
fix: 보호자 초대 알림 표시, 피보호자 목록 조회, 기기 연결 상태 분리 수정 

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/ikongserver/controller/DeviceController.java
+++ b/src/main/java/com/ikongserver/controller/DeviceController.java
@@ -1,9 +1,7 @@
 package com.ikongserver.controller;
 
-import com.ikongserver.dto.DeviceDto.ResponseDevice;
+import com.ikongserver.dto.DeviceDto;
 import com.ikongserver.service.DeviceService;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,13 +16,9 @@ public class DeviceController {
 
     private final DeviceService deviceService;
 
-    // 특정 유저의 디바이스(라즈베리파이) 연결 상태 조회
     @GetMapping("/{userId}/devices")
-    public ResponseEntity<ResponseDevice> getDevices(@PathVariable Long userId) {
-
-        ResponseDevice deviceStatuses = deviceService.getDeviceStatus(userId);
-
-        return ResponseEntity.ok(deviceStatuses);
+    public ResponseEntity<DeviceDto.DeviceStatusResponse> getDevices(@PathVariable Long userId) {
+        return ResponseEntity.ok(deviceService.getDeviceStatus(userId));
     }
 
 }

--- a/src/main/java/com/ikongserver/controller/GuardianMainController.java
+++ b/src/main/java/com/ikongserver/controller/GuardianMainController.java
@@ -18,6 +18,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 보호자 메인 화면 API.
+ * 모든 엔드포인트는 JWT 인증된 GUARDIAN 토큰을 요구한다.
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/guardians/me")
@@ -26,6 +30,9 @@ public class GuardianMainController {
     private final GuardianMainService guardianMainService;
     private final GuardianService guardianService;
 
+    /**
+     * 보호자 메인 화면 상단 카운트 (긴급/주의/외출/전체).
+     */
     @GetMapping("/dashboard")
     public ResponseEntity<ApiResponse<DashboardSummary>> getDashboard() {
         Long guardianId = currentGuardianId();
@@ -33,6 +40,9 @@ public class GuardianMainController {
         return ResponseEntity.ok(ApiResponse.ok(summary));
     }
 
+    /**
+     * 담당하는 피보호자 카드 목록.
+     */
     @GetMapping("/users")
     public ResponseEntity<ApiResponse<UserListResponse>> getMyUsers() {
         Long guardianId = currentGuardianId();
@@ -40,6 +50,9 @@ public class GuardianMainController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
+    /**
+     * 특정 피보호자 상세 (긴급 상황 UI에서 활용).
+     */
     @GetMapping("/users/{userId}")
     public ResponseEntity<ApiResponse<UserCard>> getUserDetail(@PathVariable Long userId) {
         Long guardianId = currentGuardianId();
@@ -66,6 +79,10 @@ public class GuardianMainController {
         return ResponseEntity.ok(ApiResponse.ok("초대를 거절했습니다.", null));
     }
 
+    /**
+     * SecurityContext 에서 guardianId 추출.
+     * JwtAuthenticationFilter 가 토큰의 subject(=guardianId 문자열)를 username 으로 세팅한다.
+     */
     private Long currentGuardianId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || auth.getName() == null) {

--- a/src/main/java/com/ikongserver/controller/GuardianMainController.java
+++ b/src/main/java/com/ikongserver/controller/GuardianMainController.java
@@ -1,33 +1,31 @@
 package com.ikongserver.controller;
 
 import com.ikongserver.dto.ApiResponse;
+import com.ikongserver.dto.GuardianDto;
 import com.ikongserver.dto.GuardianMainDto.DashboardSummary;
 import com.ikongserver.dto.GuardianMainDto.UserCard;
 import com.ikongserver.dto.GuardianMainDto.UserListResponse;
 import com.ikongserver.service.GuardianMainService;
+import com.ikongserver.service.GuardianService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 보호자 메인 화면 API.
- * 모든 엔드포인트는 JWT 인증된 GUARDIAN 토큰을 요구한다.
- */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/guardians/me")
 public class GuardianMainController {
 
     private final GuardianMainService guardianMainService;
+    private final GuardianService guardianService;
 
-    /**
-     * 보호자 메인 화면 상단 카운트 (긴급/주의/외출/전체).
-     */
     @GetMapping("/dashboard")
     public ResponseEntity<ApiResponse<DashboardSummary>> getDashboard() {
         Long guardianId = currentGuardianId();
@@ -35,9 +33,6 @@ public class GuardianMainController {
         return ResponseEntity.ok(ApiResponse.ok(summary));
     }
 
-    /**
-     * 담당하는 피보호자 카드 목록.
-     */
     @GetMapping("/users")
     public ResponseEntity<ApiResponse<UserListResponse>> getMyUsers() {
         Long guardianId = currentGuardianId();
@@ -45,9 +40,6 @@ public class GuardianMainController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    /**
-     * 특정 피보호자 상세 (긴급 상황 UI에서 활용).
-     */
     @GetMapping("/users/{userId}")
     public ResponseEntity<ApiResponse<UserCard>> getUserDetail(@PathVariable Long userId) {
         Long guardianId = currentGuardianId();
@@ -55,10 +47,25 @@ public class GuardianMainController {
         return ResponseEntity.ok(ApiResponse.ok(card));
     }
 
-    /**
-     * SecurityContext 에서 guardianId 추출.
-     * JwtAuthenticationFilter 가 토큰의 subject(=guardianId 문자열)를 username 으로 세팅한다.
-     */
+    @GetMapping("/invitations")
+    public ResponseEntity<ApiResponse<List<GuardianDto.PendingInvitationResponse>>> getPendingInvitations() {
+        Long guardianId = currentGuardianId();
+        List<GuardianDto.PendingInvitationResponse> list = guardianService.getPendingInvitations(guardianId);
+        return ResponseEntity.ok(ApiResponse.ok(list));
+    }
+
+    @PostMapping("/invitations/{invitationId}/accept")
+    public ResponseEntity<ApiResponse<Void>> acceptInvitation(@PathVariable Long invitationId) {
+        guardianService.acceptInvitation(invitationId);
+        return ResponseEntity.ok(ApiResponse.ok("초대를 수락했습니다.", null));
+    }
+
+    @PostMapping("/invitations/{invitationId}/reject")
+    public ResponseEntity<ApiResponse<Void>> rejectInvitation(@PathVariable Long invitationId) {
+        guardianService.rejectInvitation(invitationId);
+        return ResponseEntity.ok(ApiResponse.ok("초대를 거절했습니다.", null));
+    }
+
     private Long currentGuardianId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || auth.getName() == null) {

--- a/src/main/java/com/ikongserver/dto/DeviceDto.java
+++ b/src/main/java/com/ikongserver/dto/DeviceDto.java
@@ -2,9 +2,13 @@ package com.ikongserver.dto;
 
 public class DeviceDto {
 
-    // 디바이스 연결 유무
-    public record ResponseDevice(Long id, boolean isConnected,
-                                 String serialNum) {
+    // 단일 디바이스 연결 정보 (기존 호환)
+    public record ResponseDevice(Long id, boolean isConnected, String serialNum) {}
 
-    }
+    // 피보호자의 모든 센서 연결 상태
+    public record DeviceStatusResponse(
+        boolean raspberryConnected,
+        boolean heartSensorConnected,
+        boolean fallSensorConnected
+    ) {}
 }

--- a/src/main/java/com/ikongserver/dto/GuardianDto.java
+++ b/src/main/java/com/ikongserver/dto/GuardianDto.java
@@ -9,6 +9,11 @@ public class GuardianDto {
                                    String relation) {
     }
 
+    // 보호자에게 온 대기 중인 초대
+    public record PendingInvitationResponse(Long invitationId, String wardName, String relation,
+                                            boolean isPrimary, LocalDateTime createdAt) {
+    }
+
     // 보호자 등록 요청
     public record RequestRegister(String name, String phone, String relation, boolean isPrimary) {
     }

--- a/src/main/java/com/ikongserver/repository/GuardianRepository.java
+++ b/src/main/java/com/ikongserver/repository/GuardianRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface GuardianRepository extends JpaRepository<Guardian, Long> {
 
     Optional<Guardian> findBySocialId(String socialId);
+
+    Optional<Guardian> findByPhone(String phone);
 }

--- a/src/main/java/com/ikongserver/service/AuthService.java
+++ b/src/main/java/com/ikongserver/service/AuthService.java
@@ -8,19 +8,14 @@ import com.ikongserver.dto.AuthDto.RefreshResponse;
 import com.ikongserver.dto.AuthDto.SignupRequest;
 import com.ikongserver.dto.AuthDto.SignupResponse;
 import com.ikongserver.entity.Guardian;
-import com.ikongserver.entity.GuardianInvitation;
 import com.ikongserver.entity.LogoutToken;
-import com.ikongserver.entity.UserGuardianMap;
 import com.ikongserver.entity.Users;
 import com.ikongserver.jwt.JwtUtil;
-import com.ikongserver.repository.GuardianInvitationRepository;
 import com.ikongserver.repository.GuardianRepository;
 import com.ikongserver.repository.LogoutTokenRepository;
-import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
 import io.jsonwebtoken.Claims;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,13 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthService {
 
-    private static final int MAX_GUARDIAN_COUNT = 5;
-
     private final KakaoAuthService kakaoAuthService;
     private final UsersRepository usersRepository;
     private final GuardianRepository guardianRepository;
-    private final GuardianInvitationRepository guardianInvitationRepository;
-    private final UserGuardianMapRepository userGuardianMapRepository;
     private final LogoutTokenRepository logoutTokenRepository;
     private final JwtUtil jwtUtil;
 
@@ -76,33 +67,6 @@ public class AuthService {
                                 .phone(kakaoUser.phone())
                                 .build());
                     });
-
-            // 전화번호로 PENDING 초대 확인 및 자동 수락 (신규/기존 보호자 모두)
-            if (kakaoUser.phone() != null) {
-                List<GuardianInvitation> pendingInvitations =
-                        guardianInvitationRepository.findByPhoneAndStatus(kakaoUser.phone(), "PENDING");
-
-                for (GuardianInvitation invitation : pendingInvitations) {
-                    Users invitingUser = invitation.getUser();
-                    boolean alreadyMapped = userGuardianMapRepository
-                            .existsByUserAndGuardian(invitingUser, guardian);
-                    if (!alreadyMapped) {
-                        long activeCount = userGuardianMapRepository
-                                .countByUserAndIsActive(invitingUser, "Y");
-                        if (activeCount < MAX_GUARDIAN_COUNT) {
-                            userGuardianMapRepository.save(UserGuardianMap.builder()
-                                    .user(invitingUser)
-                                    .guardian(guardian)
-                                    .relation(invitation.getRelation())
-                                    .isPrimary(invitation.getIsPrimary() ? "Y" : "N")
-                                    .isActive("Y")
-                                    .build());
-                        }
-                    }
-                    invitation.accept();
-                }
-            }
-
             id = String.valueOf(guardian.getId());
             isNewUser = isNew[0];
         } else {
@@ -117,7 +81,6 @@ public class AuthService {
                                 .birthDate(kakaoUser.birthDate())
                                 .build());
                     });
-            // 기존 유저 카카오 최신 정보로 업데이트
             if (!isNew[0]) {
                 user.updateFromKakao(kakaoUser.name(), kakaoUser.phone(), kakaoUser.birthDate());
             }

--- a/src/main/java/com/ikongserver/service/DeviceService.java
+++ b/src/main/java/com/ikongserver/service/DeviceService.java
@@ -19,19 +19,25 @@ public class DeviceService {
 
     private final DeviceRepository deviceRepository;
 
-    // 연결 된 디바이스(라즈베리파이) 조회
-    public ResponseDevice getDeviceStatus(Long userId) {
+    // 피보호자의 모든 센서 연결 상태 조회
+    public DeviceDto.DeviceStatusResponse getDeviceStatus(Long userId) {
+        List<Device> devices = deviceRepository.findAllByUserId(userId);
 
-        Device device = deviceRepository.findByUserId(userId)
-            .orElseThrow(() -> new IllegalArgumentException("연결 된 디바이스가 없습니다."));
+        boolean heartConnected = false;
+        boolean fallConnected = false;
 
-        boolean isConnected = checkConnection(device.getLastConnectedAt());
+        for (Device device : devices) {
+            boolean connected = checkConnection(device.getLastConnectedAt());
+            String serial = device.getSerialNum() != null ? device.getSerialNum().toUpperCase() : "";
+            if (serial.contains("FALL")) {
+                fallConnected = connected;
+            } else {
+                heartConnected = connected;
+            }
+        }
 
-        return new DeviceDto.ResponseDevice(
-            device.getId(),
-            isConnected,
-            device.getSerialNum()
-        );
+        boolean raspberryConnected = heartConnected || fallConnected;
+        return new DeviceDto.DeviceStatusResponse(raspberryConnected, heartConnected, fallConnected);
     }
 
     // 디바이스(라즈베리파이) 연결 조회

--- a/src/main/java/com/ikongserver/service/GuardianService.java
+++ b/src/main/java/com/ikongserver/service/GuardianService.java
@@ -27,6 +27,7 @@ public class GuardianService {
     private final UserGuardianMapRepository userGuardianMapRepository;
     private final UsersRepository usersRepository;
 
+    // 보호자 직접 등록 — 최대 5명 제한 초과 시 예외 발생, Guardian + UserGuardianMap 동시 생성
     @Transactional
     public GuardianDto.ResponseRegister registerGuardian(Long userId, GuardianDto.RequestRegister request) {
         Users user = usersRepository.findById(userId)
@@ -64,6 +65,7 @@ public class GuardianService {
         );
     }
 
+    // 피보호자 ID로 등록된 보호자 목록 조회 (활성/비활성 포함)
     public List<GuardianDto.ResponseGuardian> getGuardians(Long userId) {
         Users user = usersRepository.findById(userId)
             .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
@@ -81,6 +83,7 @@ public class GuardianService {
             .toList();
     }
 
+    // 보호자 초대 발송 — GuardianInvitation 레코드 생성, 초대 수락 전까지 UserGuardianMap에 반영 안 됨
     @Transactional
     public GuardianDto.ResponseInvite inviteGuardian(Long userId, GuardianDto.RequestInvite request) {
         Users user = usersRepository.findById(userId)
@@ -106,6 +109,7 @@ public class GuardianService {
         );
     }
 
+    // 초대 수락 — status ACCEPTED로 변경 + UserGuardianMap 생성 (보호 관계 등록)
     @Transactional
     public void acceptInvitation(Long invitationId) {
         GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
@@ -131,6 +135,7 @@ public class GuardianService {
         }
     }
 
+    // 초대 거절 — GuardianInvitation status를 REJECTED로 변경 (중복 처리 방지는 entity에서 검증)
     @Transactional
     public void rejectInvitation(Long invitationId) {
         GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
@@ -155,6 +160,7 @@ public class GuardianService {
             .toList();
     }
 
+    // 보호자 삭제 — 실제 레코드 삭제 대신 UserGuardianMap의 isActive를 "N"으로 변경 (소프트 삭제)
     @Transactional
     public void deleteGuardian(Long userId, Long guardianId) {
         Users user = usersRepository.findById(userId)

--- a/src/main/java/com/ikongserver/service/GuardianService.java
+++ b/src/main/java/com/ikongserver/service/GuardianService.java
@@ -9,6 +9,7 @@ import com.ikongserver.repository.GuardianInvitationRepository;
 import com.ikongserver.repository.GuardianRepository;
 import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,6 @@ public class GuardianService {
     private final UserGuardianMapRepository userGuardianMapRepository;
     private final UsersRepository usersRepository;
 
-    // 보호자 직접 등록 — 최대 5명 제한 초과 시 예외 발생, Guardian + UserGuardianMap 동시 생성
     @Transactional
     public GuardianDto.ResponseRegister registerGuardian(Long userId, GuardianDto.RequestRegister request) {
         Users user = usersRepository.findById(userId)
@@ -64,7 +64,6 @@ public class GuardianService {
         );
     }
 
-    // 피보호자 ID로 등록된 보호자 목록 조회 (활성/비활성 포함)
     public List<GuardianDto.ResponseGuardian> getGuardians(Long userId) {
         Users user = usersRepository.findById(userId)
             .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
@@ -82,7 +81,6 @@ public class GuardianService {
             .toList();
     }
 
-    // 보호자 초대 발송 — GuardianInvitation 레코드 생성, 초대 수락 전까지 UserGuardianMap에 반영 안 됨
     @Transactional
     public GuardianDto.ResponseInvite inviteGuardian(Long userId, GuardianDto.RequestInvite request) {
         Users user = usersRepository.findById(userId)
@@ -108,15 +106,31 @@ public class GuardianService {
         );
     }
 
-    // 초대 수락 — GuardianInvitation status를 ACCEPTED로 변경 (중복 처리 방지는 entity에서 검증)
     @Transactional
     public void acceptInvitation(Long invitationId) {
         GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
             .orElseThrow(() -> new IllegalArgumentException("초대를 찾을 수 없습니다."));
         invitation.accept();
+
+        Users user = invitation.getUser();
+        Guardian guardian = guardianRepository.findByPhone(invitation.getPhone())
+            .orElseThrow(() -> new IllegalArgumentException("보호자를 찾을 수 없습니다."));
+
+        boolean alreadyMapped = userGuardianMapRepository.existsByUserAndGuardian(user, guardian);
+        if (!alreadyMapped) {
+            long activeCount = userGuardianMapRepository.countByUserAndIsActive(user, "Y");
+            if (activeCount < MAX_GUARDIAN_COUNT) {
+                userGuardianMapRepository.save(UserGuardianMap.builder()
+                    .user(user)
+                    .guardian(guardian)
+                    .relation(invitation.getRelation())
+                    .isPrimary(invitation.getIsPrimary() ? "Y" : "N")
+                    .isActive("Y")
+                    .build());
+            }
+        }
     }
 
-    // 초대 거절 — GuardianInvitation status를 REJECTED로 변경 (중복 처리 방지는 entity에서 검증)
     @Transactional
     public void rejectInvitation(Long invitationId) {
         GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
@@ -124,7 +138,23 @@ public class GuardianService {
         invitation.reject();
     }
 
-    // 보호자 삭제 — 실제 레코드 삭제 대신 UserGuardianMap의 isActive를 "N"으로 변경 (소프트 삭제)
+    public List<GuardianDto.PendingInvitationResponse> getPendingInvitations(Long guardianId) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+            .orElseThrow(() -> new IllegalArgumentException("보호자를 찾을 수 없습니다."));
+        if (guardian.getPhone() == null) return Collections.emptyList();
+        return guardianInvitationRepository
+            .findByPhoneAndStatus(guardian.getPhone(), "PENDING")
+            .stream()
+            .map(inv -> new GuardianDto.PendingInvitationResponse(
+                inv.getId(),
+                inv.getUser().getName(),
+                inv.getRelation(),
+                inv.getIsPrimary(),
+                inv.getCreatedAt()
+            ))
+            .toList();
+    }
+
     @Transactional
     public void deleteGuardian(Long userId, Long guardianId) {
         Users user = usersRepository.findById(userId)

--- a/src/main/java/com/ikongserver/service/KakaoAuthService.java
+++ b/src/main/java/com/ikongserver/service/KakaoAuthService.java
@@ -38,10 +38,11 @@ public class KakaoAuthService {
                 name = (String) profile.get("nickname");
             }
 
-            // 전화번호 (+82 10-xxxx-xxxx → 010-xxxx-xxxx)
+            // 전화번호 (+82 10-1234-5678 → 01012345678 숫자만)
             String rawPhone = (String) kakaoAccount.get("phone_number");
             if (rawPhone != null) {
-                phone = rawPhone.replace("+82 ", "0").replace("+82", "0");
+                phone = rawPhone.replace("+82 ", "0").replace("+82", "0")
+                        .replaceAll("[^0-9]", "");
             }
 
             // 생년 (birthyear만 수신 → YYYY-01-01)


### PR DESCRIPTION
- 카카오 로그인 시 PENDING 초대 자동 수락 제거 (보호자가 직접 수락/거절)
- acceptInvitation()에서 UserGuardianMap 생성 추가 (수락 후 피보호자 목록 반영)
- getPendingInvitations() / acceptInvitation() / rejectInvitation() 엔드포인트 추가
- 카카오 전화번호 정규화 (+82 → 01x 형식)
- DeviceService: HR/낙상 센서를 serial 번호로 구분해 개별 연결 상태 반환
- GuardianRepository: findByPhone() 추가