### PR TITLE
feat:FCM 푸시 알림 및 알림 내역 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,11 @@ application-main.properties
 application-prod.properties
 *secret*.properties
 
+### Firebase ###
+# Firebase 서비스 계정 키 — 절대 커밋하지 않음
+src/main/resources/firebase-service-account.json
+*firebase-adminsdk*.json
+
 ### OS ###
 # Mac OS를 사용하실 경우 자동으로 생기는 불필요한 숨김 파일 제외
 .DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     // 시큐리티 및 OAuth2
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    // FCM
+    implementation 'com.google.firebase:firebase-admin:9.2.0'
     // 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/com/ikongserver/IKongServerApplication.java
+++ b/src/main/java/com/ikongserver/IKongServerApplication.java
@@ -4,7 +4,9 @@ import jakarta.annotation.PostConstruct;
 import java.util.TimeZone;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class IKongServerApplication {
 

--- a/src/main/java/com/ikongserver/config/FirebaseConfig.java
+++ b/src/main/java/com/ikongserver/config/FirebaseConfig.java
@@ -1,0 +1,33 @@
+package com.ikongserver.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.io.InputStream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+@Slf4j
+@Configuration
+public class FirebaseConfig {
+
+    @PostConstruct
+    public void initialize() {
+        try {
+            if (FirebaseApp.getApps().isEmpty()) {
+                InputStream serviceAccount =
+                    new ClassPathResource("firebase-service-account.json").getInputStream();
+                FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                    .build();
+                FirebaseApp.initializeApp(options);
+                log.info("Firebase Admin SDK 초기화 성공");
+            }
+        } catch (IOException e) {
+            log.warn("firebase-service-account.json 파일을 찾을 수 없습니다. FCM 기능이 비활성화됩니다.");
+        }
+    }
+}

--- a/src/main/java/com/ikongserver/controller/DeviceController.java
+++ b/src/main/java/com/ikongserver/controller/DeviceController.java
@@ -1,9 +1,7 @@
 package com.ikongserver.controller;
 
-import com.ikongserver.dto.DeviceDto.ResponseDevice;
+import com.ikongserver.dto.DeviceDto;
 import com.ikongserver.service.DeviceService;
-import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,13 +16,9 @@ public class DeviceController {
 
     private final DeviceService deviceService;
 
-    // 특정 유저의 디바이스(라즈베리파이) 연결 상태 조회
     @GetMapping("/{userId}/devices")
-    public ResponseEntity<ResponseDevice> getDevices(@PathVariable Long userId) {
-
-        ResponseDevice deviceStatuses = deviceService.getDeviceStatus(userId);
-
-        return ResponseEntity.ok(deviceStatuses);
+    public ResponseEntity<DeviceDto.DeviceStatusResponse> getDevices(@PathVariable Long userId) {
+        return ResponseEntity.ok(deviceService.getDeviceStatus(userId));
     }
 
 }

--- a/src/main/java/com/ikongserver/controller/GuardianMainController.java
+++ b/src/main/java/com/ikongserver/controller/GuardianMainController.java
@@ -18,6 +18,10 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * 보호자 메인 화면 API.
+ * 모든 엔드포인트는 JWT 인증된 GUARDIAN 토큰을 요구한다.
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/guardians/me")
@@ -26,6 +30,9 @@ public class GuardianMainController {
     private final GuardianMainService guardianMainService;
     private final GuardianService guardianService;
 
+    /**
+     * 보호자 메인 화면 상단 카운트 (긴급/주의/외출/전체).
+     */
     @GetMapping("/dashboard")
     public ResponseEntity<ApiResponse<DashboardSummary>> getDashboard() {
         Long guardianId = currentGuardianId();
@@ -33,6 +40,9 @@ public class GuardianMainController {
         return ResponseEntity.ok(ApiResponse.ok(summary));
     }
 
+    /**
+     * 담당하는 피보호자 카드 목록.
+     */
     @GetMapping("/users")
     public ResponseEntity<ApiResponse<UserListResponse>> getMyUsers() {
         Long guardianId = currentGuardianId();
@@ -40,6 +50,9 @@ public class GuardianMainController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
+    /**
+     * 특정 피보호자 상세 (긴급 상황 UI에서 활용).
+     */
     @GetMapping("/users/{userId}")
     public ResponseEntity<ApiResponse<UserCard>> getUserDetail(@PathVariable Long userId) {
         Long guardianId = currentGuardianId();
@@ -66,6 +79,10 @@ public class GuardianMainController {
         return ResponseEntity.ok(ApiResponse.ok("초대를 거절했습니다.", null));
     }
 
+    /**
+     * SecurityContext 에서 guardianId 추출.
+     * JwtAuthenticationFilter 가 토큰의 subject(=guardianId 문자열)를 username 으로 세팅한다.
+     */
     private Long currentGuardianId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || auth.getName() == null) {

--- a/src/main/java/com/ikongserver/controller/GuardianMainController.java
+++ b/src/main/java/com/ikongserver/controller/GuardianMainController.java
@@ -1,33 +1,31 @@
 package com.ikongserver.controller;
 
 import com.ikongserver.dto.ApiResponse;
+import com.ikongserver.dto.GuardianDto;
 import com.ikongserver.dto.GuardianMainDto.DashboardSummary;
 import com.ikongserver.dto.GuardianMainDto.UserCard;
 import com.ikongserver.dto.GuardianMainDto.UserListResponse;
 import com.ikongserver.service.GuardianMainService;
+import com.ikongserver.service.GuardianService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/**
- * 보호자 메인 화면 API.
- * 모든 엔드포인트는 JWT 인증된 GUARDIAN 토큰을 요구한다.
- */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/guardians/me")
 public class GuardianMainController {
 
     private final GuardianMainService guardianMainService;
+    private final GuardianService guardianService;
 
-    /**
-     * 보호자 메인 화면 상단 카운트 (긴급/주의/외출/전체).
-     */
     @GetMapping("/dashboard")
     public ResponseEntity<ApiResponse<DashboardSummary>> getDashboard() {
         Long guardianId = currentGuardianId();
@@ -35,9 +33,6 @@ public class GuardianMainController {
         return ResponseEntity.ok(ApiResponse.ok(summary));
     }
 
-    /**
-     * 담당하는 피보호자 카드 목록.
-     */
     @GetMapping("/users")
     public ResponseEntity<ApiResponse<UserListResponse>> getMyUsers() {
         Long guardianId = currentGuardianId();
@@ -45,9 +40,6 @@ public class GuardianMainController {
         return ResponseEntity.ok(ApiResponse.ok(response));
     }
 
-    /**
-     * 특정 피보호자 상세 (긴급 상황 UI에서 활용).
-     */
     @GetMapping("/users/{userId}")
     public ResponseEntity<ApiResponse<UserCard>> getUserDetail(@PathVariable Long userId) {
         Long guardianId = currentGuardianId();
@@ -55,10 +47,25 @@ public class GuardianMainController {
         return ResponseEntity.ok(ApiResponse.ok(card));
     }
 
-    /**
-     * SecurityContext 에서 guardianId 추출.
-     * JwtAuthenticationFilter 가 토큰의 subject(=guardianId 문자열)를 username 으로 세팅한다.
-     */
+    @GetMapping("/invitations")
+    public ResponseEntity<ApiResponse<List<GuardianDto.PendingInvitationResponse>>> getPendingInvitations() {
+        Long guardianId = currentGuardianId();
+        List<GuardianDto.PendingInvitationResponse> list = guardianService.getPendingInvitations(guardianId);
+        return ResponseEntity.ok(ApiResponse.ok(list));
+    }
+
+    @PostMapping("/invitations/{invitationId}/accept")
+    public ResponseEntity<ApiResponse<Void>> acceptInvitation(@PathVariable Long invitationId) {
+        guardianService.acceptInvitation(invitationId);
+        return ResponseEntity.ok(ApiResponse.ok("초대를 수락했습니다.", null));
+    }
+
+    @PostMapping("/invitations/{invitationId}/reject")
+    public ResponseEntity<ApiResponse<Void>> rejectInvitation(@PathVariable Long invitationId) {
+        guardianService.rejectInvitation(invitationId);
+        return ResponseEntity.ok(ApiResponse.ok("초대를 거절했습니다.", null));
+    }
+
     private Long currentGuardianId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         if (auth == null || auth.getName() == null) {

--- a/src/main/java/com/ikongserver/controller/NotificationController.java
+++ b/src/main/java/com/ikongserver/controller/NotificationController.java
@@ -2,6 +2,8 @@ package com.ikongserver.controller;
 
 import com.ikongserver.dto.NotificationDto.CreateNotificationRequest;
 import com.ikongserver.dto.NotificationDto.CreateNotificationResponse;
+import com.ikongserver.dto.NotificationDto.EmergencyEventDetailResponse;
+import com.ikongserver.dto.NotificationDto.FcmTokenRequest;
 import com.ikongserver.dto.NotificationDto.NotificationListResponse;
 import com.ikongserver.service.NotificationService;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -70,6 +73,25 @@ public class NotificationController {
     @PatchMapping("/{notificationId}/read")
     public ResponseEntity<Void> markAsRead(@PathVariable Long notificationId) {
         notificationService.markAsRead(notificationId);
+        return ResponseEntity.ok().build();
+    }
+
+    // 긴급 알림 상세 조회 — 이름, 이벤트 유형, 발생 시각, 상세 내용 반환
+    @GetMapping("/events/{eventId}")
+    public ResponseEntity<EmergencyEventDetailResponse> getEmergencyEventDetail(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal UserDetails userDetails) {
+        Long guardianId = Long.parseLong(userDetails.getUsername());
+        return ResponseEntity.ok(notificationService.getEmergencyEventDetail(eventId, guardianId));
+    }
+
+    // 보호자 FCM 토큰 등록/갱신 — 앱 실행 시 최신 토큰을 서버에 저장
+    @PutMapping("/fcm-token")
+    public ResponseEntity<Void> updateFcmToken(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody FcmTokenRequest request) {
+        Long guardianId = Long.parseLong(userDetails.getUsername());
+        notificationService.updateFcmToken(guardianId, request.fcmToken());
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/ikongserver/controller/UsersController.java
+++ b/src/main/java/com/ikongserver/controller/UsersController.java
@@ -1,11 +1,16 @@
 package com.ikongserver.controller;
 
+import com.ikongserver.dto.UserDto.FcmTokenRequest;
 import com.ikongserver.dto.UserDto.MainProfileResponse;
 import com.ikongserver.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,9 +24,17 @@ public class UsersController {
     // 메인 화면 이름 및 상태 표시
     @GetMapping("/{userId}/main")
     public ResponseEntity<MainProfileResponse> getUser(@PathVariable Long userId) {
-
         MainProfileResponse response = userService.getMainProfile(userId);
         return ResponseEntity.ok(response);
+    }
 
+    // 피보호자 FCM 토큰 등록/갱신 — 앱 실행 시 최신 토큰을 서버에 저장
+    @PutMapping("/fcm-token")
+    public ResponseEntity<Void> updateFcmToken(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @RequestBody FcmTokenRequest request) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        userService.updateFcmToken(userId, request.fcmToken());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/ikongserver/dto/DeviceDto.java
+++ b/src/main/java/com/ikongserver/dto/DeviceDto.java
@@ -2,9 +2,13 @@ package com.ikongserver.dto;
 
 public class DeviceDto {
 
-    // 디바이스 연결 유무
-    public record ResponseDevice(Long id, boolean isConnected,
-                                 String serialNum) {
+    // 단일 디바이스 연결 정보 (기존 호환)
+    public record ResponseDevice(Long id, boolean isConnected, String serialNum) {}
 
-    }
+    // 피보호자의 모든 센서 연결 상태
+    public record DeviceStatusResponse(
+        boolean raspberryConnected,
+        boolean heartSensorConnected,
+        boolean fallSensorConnected
+    ) {}
 }

--- a/src/main/java/com/ikongserver/dto/GuardianDto.java
+++ b/src/main/java/com/ikongserver/dto/GuardianDto.java
@@ -9,6 +9,11 @@ public class GuardianDto {
                                    String relation) {
     }
 
+    // 보호자에게 온 대기 중인 초대
+    public record PendingInvitationResponse(Long invitationId, String wardName, String relation,
+                                            boolean isPrimary, LocalDateTime createdAt) {
+    }
+
     // 보호자 등록 요청
     public record RequestRegister(String name, String phone, String relation, boolean isPrimary) {
     }

--- a/src/main/java/com/ikongserver/dto/NotificationDto.java
+++ b/src/main/java/com/ikongserver/dto/NotificationDto.java
@@ -16,7 +16,7 @@ public class NotificationDto {
     }
 
     public record NotificationItem(Long notificationId, String userName, String eventType,
-                                   String message, String status, LocalDateTime sentAt,
+                                   String message, String eventStatus, LocalDateTime sentAt,
                                    String readYN) {
 
     }
@@ -30,5 +30,8 @@ public class NotificationDto {
                                                String eventType,
                                                String description, LocalDateTime occurredAt) {
 
+    }
+
+    public record FcmTokenRequest(String fcmToken) {
     }
 }

--- a/src/main/java/com/ikongserver/dto/UserDto.java
+++ b/src/main/java/com/ikongserver/dto/UserDto.java
@@ -9,6 +9,9 @@ public class UserDto {
 
     }
 
+    public record FcmTokenRequest(String fcmToken) {
+    }
+
     // 보호자 화면에서의 피보호자 상태 디테일 (이름, 관계, 상태, 실시간 생체 데이터(심박수, 호흡수, 최근 업데이트 시간), 활동 상태 (수면, 낙상, 활동 중))
     public record UserStateDetailResponse(Long userId, String name, String relationship,
                                           String overallStatus, int heartRate,

--- a/src/main/java/com/ikongserver/entity/EmergencyEvent.java
+++ b/src/main/java/com/ikongserver/entity/EmergencyEvent.java
@@ -38,6 +38,7 @@ public class EmergencyEvent {
 
     private String eventType;
     private String status;
+    private String severity; // WARNING(주의) or CRITICAL(심각)
 
     @CreationTimestamp
     @Column(updatable = false)
@@ -48,20 +49,24 @@ public class EmergencyEvent {
     }
 
     public String getEventDescription() {
+        String level = "CRITICAL".equals(this.severity)
+            ? "[심각] 즉시 병원 방문이 필요합니다."
+            : "[주의] 상태를 주의깊게 살펴보세요.";
         return switch (this.eventType) {
-            case "FALL" -> "낙상이 감지되었습니다.";
-            case "HEART_ISSUE" -> "심박수 이상이 감지되었습니다.";
-            case "BREATH_ISSUE" -> "호흡수 이상이 감지되었습니다.";
+            case "FALL" -> "낙상이 감지되었습니다. [심각] 즉시 확인이 필요합니다.";
+            case "HEART_ISSUE" -> "심박수 이상이 감지되었습니다. " + level;
+            case "BREATH_ISSUE" -> "호흡수 이상이 감지되었습니다. " + level;
             default -> "이상이 감지되었습니다.";
         };
     }
 
     @Builder
-    public EmergencyEvent(Users user, Device device,String eventType, String status) {
+    public EmergencyEvent(Users user, Device device, String eventType, String status, String severity) {
         this.user = user;
         this.device = device;
         this.eventType = eventType;
         this.status = status;
+        this.severity = severity;
     }
 
 }

--- a/src/main/java/com/ikongserver/entity/Guardian.java
+++ b/src/main/java/com/ikongserver/entity/Guardian.java
@@ -33,9 +33,15 @@ public class Guardian {
 
     private String socialId;
 
+    private String fcmToken;
+
     @CreationTimestamp
     @Column(updatable = false)
     private LocalDateTime createdAt;
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
 
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;

--- a/src/main/java/com/ikongserver/entity/Users.java
+++ b/src/main/java/com/ikongserver/entity/Users.java
@@ -41,6 +41,11 @@ public class Users {
     private LocalDateTime createdAt;
 
     private String socialId;
+    private String fcmToken;
+
+    public void updateFcmToken(String fcmToken) {
+        this.fcmToken = fcmToken;
+    }
 
     public void updatePassword(String encodedPassword) {
         this.password = encodedPassword;

--- a/src/main/java/com/ikongserver/repository/DeviceRepository.java
+++ b/src/main/java/com/ikongserver/repository/DeviceRepository.java
@@ -1,6 +1,7 @@
 package com.ikongserver.repository;
 
 import com.ikongserver.entity.Device;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +13,7 @@ public interface DeviceRepository extends JpaRepository<Device, Long> {
 
     // 한 피보호자의 모든 디바이스 조회 (멀티 센서 지원)
     List<Device> findAllByUserId(Long userId);
+
+    // 마지막 연결 시각이 기준 시각 이전인 기기 조회 (연결 끊김 감지용)
+    List<Device> findByLastConnectedAtBefore(LocalDateTime threshold);
 }

--- a/src/main/java/com/ikongserver/repository/GuardianRepository.java
+++ b/src/main/java/com/ikongserver/repository/GuardianRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface GuardianRepository extends JpaRepository<Guardian, Long> {
 
     Optional<Guardian> findBySocialId(String socialId);
+
+    Optional<Guardian> findByPhone(String phone);
 }

--- a/src/main/java/com/ikongserver/repository/NotificationRepository.java
+++ b/src/main/java/com/ikongserver/repository/NotificationRepository.java
@@ -9,16 +9,20 @@ import org.springframework.data.repository.query.Param;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
-    // 보호자 기준 조회
+    // 보호자 기준 전체 조회
     Page<Notification> findByGuardianId(Long guardianId, Pageable pageable);
-    Page<Notification> findByGuardianIdAndStatus(Long guardianId, String status, Pageable pageable);
 
-    // 피보호자(userId) 기준 조회
+    // 보호자 기준 이벤트 상태(PENDING/RESOLVED) 필터 조회
+    @Query("SELECT n FROM Notification n WHERE n.guardian.id = :guardianId AND n.emergencyEvent.status = :eventStatus")
+    Page<Notification> findByGuardianIdAndEventStatus(@Param("guardianId") Long guardianId, @Param("eventStatus") String eventStatus, Pageable pageable);
+
+    // 피보호자(userId) 기준 전체 조회
     @Query("SELECT n FROM Notification n WHERE n.emergencyEvent.user.id = :userId")
     Page<Notification> findByUserId(@Param("userId") Long userId, Pageable pageable);
 
-    @Query("SELECT n FROM Notification n WHERE n.emergencyEvent.user.id = :userId AND n.status = :status")
-    Page<Notification> findByUserIdAndStatus(@Param("userId") Long userId, @Param("status") String status, Pageable pageable);
+    // 피보호자(userId) 기준 이벤트 상태 필터 조회
+    @Query("SELECT n FROM Notification n WHERE n.emergencyEvent.user.id = :userId AND n.emergencyEvent.status = :eventStatus")
+    Page<Notification> findByUserIdAndEventStatus(@Param("userId") Long userId, @Param("eventStatus") String eventStatus, Pageable pageable);
 
     long countByGuardianIdAndReadYN(Long guardianId, String readYN);
 }

--- a/src/main/java/com/ikongserver/repository/UserGuardianMapRepository.java
+++ b/src/main/java/com/ikongserver/repository/UserGuardianMapRepository.java
@@ -24,7 +24,4 @@ public interface UserGuardianMapRepository extends JpaRepository<UserGuardianMap
     Optional<UserGuardianMap> findByUserIdAndGuardianId(Long userId, Long guardianId);
     boolean existsByUserIdAndGuardianId(Long userId, Long guardianId);
 
-    // 피보호자 보호자 관계
-    String findByUserId (Long userId);
-
 }

--- a/src/main/java/com/ikongserver/repository/VitalRepository.java
+++ b/src/main/java/com/ikongserver/repository/VitalRepository.java
@@ -1,6 +1,8 @@
 package com.ikongserver.repository;
 
+import com.ikongserver.entity.Users;
 import com.ikongserver.entity.Vital;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -22,4 +24,8 @@ public interface VitalRepository extends JpaRepository<Vital, Long> {
     List<Vital> findLatestVitalPerDevice(@Param("userId") Long userId);
 
     Optional<Vital> findFirstByUserIdOrderByRecordedAtDesc(Long userId);
+
+    long countByUserAndRecordedAtAfter(Users user, LocalDateTime from);
+
+    List<Vital> findByUserAndRecordedAtAfter(Users user, LocalDateTime from);
 }

--- a/src/main/java/com/ikongserver/service/AuthService.java
+++ b/src/main/java/com/ikongserver/service/AuthService.java
@@ -8,19 +8,14 @@ import com.ikongserver.dto.AuthDto.RefreshResponse;
 import com.ikongserver.dto.AuthDto.SignupRequest;
 import com.ikongserver.dto.AuthDto.SignupResponse;
 import com.ikongserver.entity.Guardian;
-import com.ikongserver.entity.GuardianInvitation;
 import com.ikongserver.entity.LogoutToken;
-import com.ikongserver.entity.UserGuardianMap;
 import com.ikongserver.entity.Users;
 import com.ikongserver.jwt.JwtUtil;
-import com.ikongserver.repository.GuardianInvitationRepository;
 import com.ikongserver.repository.GuardianRepository;
 import com.ikongserver.repository.LogoutTokenRepository;
-import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
 import io.jsonwebtoken.Claims;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,13 +24,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuthService {
 
-    private static final int MAX_GUARDIAN_COUNT = 5;
-
     private final KakaoAuthService kakaoAuthService;
     private final UsersRepository usersRepository;
     private final GuardianRepository guardianRepository;
-    private final GuardianInvitationRepository guardianInvitationRepository;
-    private final UserGuardianMapRepository userGuardianMapRepository;
     private final LogoutTokenRepository logoutTokenRepository;
     private final JwtUtil jwtUtil;
 
@@ -76,33 +67,6 @@ public class AuthService {
                                 .phone(kakaoUser.phone())
                                 .build());
                     });
-
-            // 전화번호로 PENDING 초대 확인 및 자동 수락 (신규/기존 보호자 모두)
-            if (kakaoUser.phone() != null) {
-                List<GuardianInvitation> pendingInvitations =
-                        guardianInvitationRepository.findByPhoneAndStatus(kakaoUser.phone(), "PENDING");
-
-                for (GuardianInvitation invitation : pendingInvitations) {
-                    Users invitingUser = invitation.getUser();
-                    boolean alreadyMapped = userGuardianMapRepository
-                            .existsByUserAndGuardian(invitingUser, guardian);
-                    if (!alreadyMapped) {
-                        long activeCount = userGuardianMapRepository
-                                .countByUserAndIsActive(invitingUser, "Y");
-                        if (activeCount < MAX_GUARDIAN_COUNT) {
-                            userGuardianMapRepository.save(UserGuardianMap.builder()
-                                    .user(invitingUser)
-                                    .guardian(guardian)
-                                    .relation(invitation.getRelation())
-                                    .isPrimary(invitation.getIsPrimary() ? "Y" : "N")
-                                    .isActive("Y")
-                                    .build());
-                        }
-                    }
-                    invitation.accept();
-                }
-            }
-
             id = String.valueOf(guardian.getId());
             isNewUser = isNew[0];
         } else {
@@ -117,7 +81,6 @@ public class AuthService {
                                 .birthDate(kakaoUser.birthDate())
                                 .build());
                     });
-            // 기존 유저 카카오 최신 정보로 업데이트
             if (!isNew[0]) {
                 user.updateFromKakao(kakaoUser.name(), kakaoUser.phone(), kakaoUser.birthDate());
             }

--- a/src/main/java/com/ikongserver/service/DeviceMonitorService.java
+++ b/src/main/java/com/ikongserver/service/DeviceMonitorService.java
@@ -1,0 +1,67 @@
+package com.ikongserver.service;
+
+import com.ikongserver.entity.Device;
+import com.ikongserver.entity.Guardian;
+import com.ikongserver.entity.UserGuardianMap;
+import com.ikongserver.repository.DeviceRepository;
+import com.ikongserver.repository.UserGuardianMapRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class DeviceMonitorService {
+
+    // 기기 연결 끊김 기준 — 10분 이상 데이터 없으면 연결 끊김으로 판단
+    private static final long DISCONNECT_THRESHOLD_MINUTES = 10;
+
+    // 알림 쿨다운 — 연결 끊김 알림 30분마다 재발송 (반복 알림 방지)
+    private static final long ALERT_COOLDOWN_MS = 30 * 60 * 1000L;
+    private final Map<Long, Long> lastAlertTimeMap = new ConcurrentHashMap<>();
+
+    private final DeviceRepository deviceRepository;
+    private final UserGuardianMapRepository userGuardianMapRepository;
+    private final FcmService fcmService;
+
+    // 1분마다 기기 연결 상태 확인
+    @Transactional
+    @Scheduled(fixedDelay = 60000)
+    public void checkDisconnectedDevices() {
+        LocalDateTime threshold = LocalDateTime.now().minusMinutes(DISCONNECT_THRESHOLD_MINUTES);
+        List<Device> disconnectedDevices = deviceRepository.findByLastConnectedAtBefore(threshold);
+
+        for (Device device : disconnectedDevices) {
+            Long deviceId = device.getId();
+            long now = System.currentTimeMillis();
+            Long lastAlertTime = lastAlertTimeMap.get(deviceId);
+
+            if (lastAlertTime != null && now - lastAlertTime < ALERT_COOLDOWN_MS) {
+                continue; // 쿨다운 중
+            }
+
+            lastAlertTimeMap.put(deviceId, now);
+
+            List<UserGuardianMap> mappings = userGuardianMapRepository.findByUser(device.getUser())
+                .stream().filter(m -> "Y".equals(m.getIsActive())).toList();
+
+            for (UserGuardianMap mapping : mappings) {
+                Guardian guardian = mapping.getGuardian();
+                fcmService.sendPushNotification(
+                    guardian.getFcmToken(),
+                    "기기 연결 끊김",
+                    device.getUser().getName() + "님의 기기와 연결이 끊겼습니다. 확인해주세요.",
+                    "ALERT"
+                );
+            }
+            log.info("기기 연결 끊김 알림 발송 — deviceId: {}", deviceId);
+        }
+    }
+}

--- a/src/main/java/com/ikongserver/service/DeviceService.java
+++ b/src/main/java/com/ikongserver/service/DeviceService.java
@@ -19,19 +19,25 @@ public class DeviceService {
 
     private final DeviceRepository deviceRepository;
 
-    // 연결 된 디바이스(라즈베리파이) 조회
-    public ResponseDevice getDeviceStatus(Long userId) {
+    // 피보호자의 모든 센서 연결 상태 조회
+    public DeviceDto.DeviceStatusResponse getDeviceStatus(Long userId) {
+        List<Device> devices = deviceRepository.findAllByUserId(userId);
 
-        Device device = deviceRepository.findByUserId(userId)
-            .orElseThrow(() -> new IllegalArgumentException("연결 된 디바이스가 없습니다."));
+        boolean heartConnected = false;
+        boolean fallConnected = false;
 
-        boolean isConnected = checkConnection(device.getLastConnectedAt());
+        for (Device device : devices) {
+            boolean connected = checkConnection(device.getLastConnectedAt());
+            String serial = device.getSerialNum() != null ? device.getSerialNum().toUpperCase() : "";
+            if (serial.contains("FALL")) {
+                fallConnected = connected;
+            } else {
+                heartConnected = connected;
+            }
+        }
 
-        return new DeviceDto.ResponseDevice(
-            device.getId(),
-            isConnected,
-            device.getSerialNum()
-        );
+        boolean raspberryConnected = heartConnected || fallConnected;
+        return new DeviceDto.DeviceStatusResponse(raspberryConnected, heartConnected, fallConnected);
     }
 
     // 디바이스(라즈베리파이) 연결 조회

--- a/src/main/java/com/ikongserver/service/EmergencyEventService.java
+++ b/src/main/java/com/ikongserver/service/EmergencyEventService.java
@@ -8,13 +8,20 @@ import com.ikongserver.dto.VitalDto.VitalRequestDto;
 import com.ikongserver.entity.Device;
 import com.ikongserver.entity.EmergencyEvent;
 import com.ikongserver.entity.Guardian;
+import com.ikongserver.entity.Notification;
 import com.ikongserver.entity.UserGuardianMap;
 import com.ikongserver.entity.Users;
+import com.ikongserver.entity.Vital;
 import com.ikongserver.repository.EmergencyEventRepository;
 import com.ikongserver.repository.GuardianRepository;
+import com.ikongserver.repository.NotificationRepository;
 import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
+import com.ikongserver.repository.VitalRepository;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,53 +30,240 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class EmergencyEventService {
 
+    // 고령자 표준 임계값 — 개인 데이터 부족 시 fallback
+    private static final int ELDERLY_HR_WARN_LOW = 60, ELDERLY_HR_WARN_HIGH = 100;
+    private static final int ELDERLY_HR_CRIT_LOW = 55, ELDERLY_HR_CRIT_HIGH = 120;
+    private static final int ELDERLY_BR_WARN_LOW = 12, ELDERLY_BR_WARN_HIGH = 20;
+    private static final int ELDERLY_BR_CRIT_LOW = 10, ELDERLY_BR_CRIT_HIGH = 25;
+
+    // 개인 기준선 임계 비율 — 중앙값 기준 ±15% WARNING, ±30% CRITICAL
+    private static final double WARNING_RATIO = 0.15;
+    private static final double CRITICAL_RATIO = 0.30;
+
+    // 연속 이상 감지 기준 — 초 단위 (매초 데이터 수신 기준)
+    private static final int WARNING_CONSECUTIVE = 30;  // 30초 연속 이상
+    private static final int CRITICAL_CONSECUTIVE = 60; // 60초 연속 이상
+
+    // 개인 기준선 최소 데이터 수 — 3일치(25,920개) 이상이어야 신뢰 가능
+    private static final long MIN_RECORDS_FOR_BASELINE = 25920L;
+
+    // 개인 기준선 캐시 — 6시간마다 재계산 (매초 DB 조회 방지)
+    private static final long BASELINE_CACHE_TTL = 6 * 60 * 60 * 1000L;
+    private final Map<Long, int[]> baselineCache = new ConcurrentHashMap<>();
+    private final Map<Long, Long> baselineCacheTime = new ConcurrentHashMap<>();
+
+    // 연속 이상 카운터 — userId별 심박수/호흡수 연속 이상 횟수
+    private final Map<Long, Integer> heartConsecutiveMap = new ConcurrentHashMap<>();
+    private final Map<Long, Integer> breathConsecutiveMap = new ConcurrentHashMap<>();
+
+    // 낙상 이벤트 쿨다운 — 5분 이내 중복 이벤트 방지
+    private static final long FALL_COOLDOWN_MS = 5 * 60 * 1000L;
+    private final Map<Long, Long> lastFallEventTimeMap = new ConcurrentHashMap<>();
+
+    // 심박수/호흡수 CRITICAL 지속 시 5분마다 재알림
+    private static final long VITAL_RECALERT_MS = 5 * 60 * 1000L;
+    private final Map<Long, Long> lastHeartEventTimeMap = new ConcurrentHashMap<>();
+    private final Map<Long, Long> lastBreathEventTimeMap = new ConcurrentHashMap<>();
+
     private final EmergencyEventRepository emergencyEventRepository;
     private final UsersRepository userRepository;
     private final GuardianRepository guardianRepository;
     private final UserGuardianMapRepository userGuardianMapRepository;
+    private final NotificationRepository notificationRepository;
+    private final VitalRepository vitalRepository;
+    private final FcmService fcmService;
 
-    // 낙상 감지 여부 확인 — isFallDetected=true면 FALL 이벤트 저장 후 true 반환 (VitalService에서 호출)
+    // 낙상 감지 — 5분 쿨다운으로 중복 이벤트 방지, CRITICAL 이벤트 저장 + 보호자 알림 + FCM 발송
+    @Transactional
     public boolean checkFallEvent(VitalRequestDto vitalDto, Users user, Device device) {
-        if (vitalDto.isFallDetected()) {
-            EmergencyEvent fallEvent = EmergencyEvent.builder()
-                .user(user)
-                .eventType("FALL")
-                .status("PENDING")
-                .device(device)
-                .build();
-            emergencyEventRepository.save(fallEvent);
-            return true;
+        if (!vitalDto.isFallDetected()) return false;
+
+        Long userId = user.getId();
+        long now = System.currentTimeMillis();
+        Long lastFallTime = lastFallEventTimeMap.get(userId);
+
+        if (lastFallTime != null && now - lastFallTime < FALL_COOLDOWN_MS) {
+            return true; // 쿨다운 중 — 이벤트 생성 없이 긴급 상태만 유지
         }
-        return false;
+
+        lastFallEventTimeMap.put(userId, now);
+        EmergencyEvent fallEvent = EmergencyEvent.builder()
+            .user(user)
+            .eventType("FALL")
+            .status("PENDING")
+            .severity("CRITICAL")
+            .device(device)
+            .build();
+        emergencyEventRepository.save(fallEvent);
+
+        String message = user.getName() + "낙상이 감지되었습니다. [심각] 즉시 확인이 필요합니다.";
+        createNotificationsAndPush(fallEvent, user, "낙상 감지", message);
+        return true;
     }
 
-    // 심박수(60~120 정상) / 호흡수(10~30 정상) 이상 여부 확인 — 범위 초과 시 각각 이벤트 저장
+    // 심박수/호흡수 이상 감지 — 개인 기준선(7일 중앙값) 기반, 연속 30초→WARNING / 60초→CRITICAL
+    // 개인 데이터 3일 미만 시 고령자 표준 임계값으로 자동 전환
+    @Transactional
     public boolean checkHeartBreathEvent(VitalRequestDto vitalDto, Users user, Device device) {
         boolean isIssueDetected = false;
+        Long userId = user.getId();
+        int[] baseline = getPersonalBaseline(user);
 
-        if (vitalDto.heartRate() >= 120 || vitalDto.heartRate() <= 60) {
-            EmergencyEvent heartEvent = EmergencyEvent.builder()
-                .user(user)
-                .eventType("HEART_ISSUE")
-                .status("PENDING")
-                .device(device)
-                .build();
-            emergencyEventRepository.save(heartEvent);
-            isIssueDetected = true;
+        // 심박수 연속 이상 감지 — 30초 WARNING, 60초 CRITICAL, 이후 5분마다 CRITICAL 재알림
+        int hr = vitalDto.heartRate();
+        if (isAbnormal(hr, baseline, true)) {
+            int count = heartConsecutiveMap.merge(userId, 1, Integer::sum);
+            if (count == WARNING_CONSECUTIVE) {
+                String severity = isCritical(hr, baseline, true) ? "CRITICAL" : "WARNING";
+                saveHeartEvent(user, device, severity);
+                lastHeartEventTimeMap.put(userId, System.currentTimeMillis());
+                isIssueDetected = true;
+            } else if (count == CRITICAL_CONSECUTIVE) {
+                saveHeartEvent(user, device, "CRITICAL");
+                lastHeartEventTimeMap.put(userId, System.currentTimeMillis());
+                isIssueDetected = true;
+            } else if (count > CRITICAL_CONSECUTIVE) {
+                long now = System.currentTimeMillis();
+                Long lastTime = lastHeartEventTimeMap.get(userId);
+                if (lastTime == null || now - lastTime >= VITAL_RECALERT_MS) {
+                    saveHeartEvent(user, device, "CRITICAL");
+                    lastHeartEventTimeMap.put(userId, now);
+                    isIssueDetected = true;
+                }
+            }
+        } else {
+            heartConsecutiveMap.put(userId, 0);
         }
 
-        if (vitalDto.breathRate() >= 30 || vitalDto.breathRate() <= 10) {
-            EmergencyEvent breathEvent = EmergencyEvent.builder()
-                .user(user)
-                .eventType("BREATH_ISSUE")
-                .status("PENDING")
-                .device(device)
-                .build();
-            emergencyEventRepository.save(breathEvent);
-            isIssueDetected = true;
+        // 호흡수 연속 이상 감지 — 30초 WARNING, 60초 CRITICAL, 이후 5분마다 CRITICAL 재알림
+        int br = vitalDto.breathRate();
+        if (isAbnormal(br, baseline, false)) {
+            int count = breathConsecutiveMap.merge(userId, 1, Integer::sum);
+            if (count == WARNING_CONSECUTIVE) {
+                String severity = isCritical(br, baseline, false) ? "CRITICAL" : "WARNING";
+                saveBreathEvent(user, device, severity);
+                lastBreathEventTimeMap.put(userId, System.currentTimeMillis());
+                isIssueDetected = true;
+            } else if (count == CRITICAL_CONSECUTIVE) {
+                saveBreathEvent(user, device, "CRITICAL");
+                lastBreathEventTimeMap.put(userId, System.currentTimeMillis());
+                isIssueDetected = true;
+            } else if (count > CRITICAL_CONSECUTIVE) {
+                long now = System.currentTimeMillis();
+                Long lastTime = lastBreathEventTimeMap.get(userId);
+                if (lastTime == null || now - lastTime >= VITAL_RECALERT_MS) {
+                    saveBreathEvent(user, device, "CRITICAL");
+                    lastBreathEventTimeMap.put(userId, now);
+                    isIssueDetected = true;
+                }
+            }
+        } else {
+            breathConsecutiveMap.put(userId, 0);
         }
 
         return isIssueDetected;
+    }
+
+    // 개인 기준선(중앙값) 반환 — 캐시 유효하면 재사용, 만료 시 재계산
+    // 데이터 부족(3일 미만)이면 null 반환 → 고령자 표준 임계값 사용
+    private int[] getPersonalBaseline(Users user) {
+        Long userId = user.getId();
+        Long lastCalc = baselineCacheTime.get(userId);
+
+        if (lastCalc != null
+            && System.currentTimeMillis() - lastCalc < BASELINE_CACHE_TTL
+            && baselineCache.containsKey(userId)) {
+            return baselineCache.get(userId);
+        }
+
+        long count = vitalRepository.countByUserAndRecordedAtAfter(user, LocalDateTime.now().minusDays(7));
+        if (count < MIN_RECORDS_FOR_BASELINE) {
+            return null;
+        }
+
+        List<Vital> vitals = vitalRepository.findByUserAndRecordedAtAfter(user, LocalDateTime.now().minusDays(7));
+        int medianHR = calculateMedian(vitals.stream().map(Vital::getHeartRate).sorted().toList());
+        int medianBR = calculateMedian(vitals.stream().map(Vital::getBreathRate).sorted().toList());
+
+        int[] baseline = {medianHR, medianBR};
+        baselineCache.put(userId, baseline);
+        baselineCacheTime.put(userId, System.currentTimeMillis());
+        return baseline;
+    }
+
+    // 이상 여부 판단 — baseline null이면 고령자 표준 임계값, 있으면 개인 중앙값 ±15%
+    private boolean isAbnormal(int value, int[] baseline, boolean isHeart) {
+        if (baseline == null) {
+            return isHeart
+                ? (value < ELDERLY_HR_WARN_LOW || value > ELDERLY_HR_WARN_HIGH)
+                : (value < ELDERLY_BR_WARN_LOW || value > ELDERLY_BR_WARN_HIGH);
+        }
+        int median = isHeart ? baseline[0] : baseline[1];
+        return value < median * (1 - WARNING_RATIO) || value > median * (1 + WARNING_RATIO);
+    }
+
+    // 심각 여부 판단 — baseline null이면 고령자 표준 임계값, 있으면 개인 중앙값 ±30%
+    private boolean isCritical(int value, int[] baseline, boolean isHeart) {
+        if (baseline == null) {
+            return isHeart
+                ? (value < ELDERLY_HR_CRIT_LOW || value > ELDERLY_HR_CRIT_HIGH)
+                : (value < ELDERLY_BR_CRIT_LOW || value > ELDERLY_BR_CRIT_HIGH);
+        }
+        int median = isHeart ? baseline[0] : baseline[1];
+        return value < median * (1 - CRITICAL_RATIO) || value > median * (1 + CRITICAL_RATIO);
+    }
+
+    private int calculateMedian(List<Integer> sorted) {
+        int size = sorted.size();
+        if (size == 0) return 0;
+        return size % 2 == 0
+            ? (sorted.get(size / 2 - 1) + sorted.get(size / 2)) / 2
+            : sorted.get(size / 2);
+    }
+
+    private void saveHeartEvent(Users user, Device device, String severity) {
+        EmergencyEvent event = EmergencyEvent.builder()
+            .user(user).eventType("HEART_ISSUE").status("PENDING").severity(severity).device(device).build();
+        emergencyEventRepository.save(event);
+        boolean isCritical = "CRITICAL".equals(severity);
+        String title = isCritical ? "[심각] 심박수 위험" : "[주의] 심박수 이상";
+        String message = isCritical
+            ? user.getName() + "심박수가 위험 수준입니다. 즉시 확인이 필요합니다."
+            : user.getName() + "심박수가 평소와 다르게 측정되고 있습니다. 상태를 주의깊게 살펴보세요.";
+        createNotificationsAndPush(event, user, title, message);
+    }
+
+    private void saveBreathEvent(Users user, Device device, String severity) {
+        EmergencyEvent event = EmergencyEvent.builder()
+            .user(user).eventType("BREATH_ISSUE").status("PENDING").severity(severity).device(device).build();
+        emergencyEventRepository.save(event);
+        boolean isCritical = "CRITICAL".equals(severity);
+        String title = isCritical ? "[심각] 호흡수 위험" : "[주의] 호흡수 이상";
+        String message = isCritical
+            ? user.getName() + "호흡수가 위험 수준입니다. 즉시 확인이 필요합니다."
+            : user.getName() + "호흡수가 평소와 다르게 측정되고 있습니다. 상태를 주의깊게 살펴보세요.";
+        createNotificationsAndPush(event, user, title, message);
+    }
+
+    // 이벤트 발생 시 활성화된 모든 보호자에게 Notification 저장 + FCM 푸시 전송
+    // 주의/심각/낙상 모두 긴급 알림으로 처리 — notificationType: "EMERGENCY"
+    private void createNotificationsAndPush(EmergencyEvent event, Users user, String fcmTitle, String message) {
+        String notificationType = "EMERGENCY";
+
+        List<UserGuardianMap> mappings = userGuardianMapRepository.findByUser(user).stream()
+            .filter(m -> "Y".equals(m.getIsActive()))
+            .toList();
+
+        for (UserGuardianMap mapping : mappings) {
+            Guardian guardian = mapping.getGuardian();
+            notificationRepository.save(Notification.builder()
+                .emergencyEvent(event)
+                .guardian(guardian)
+                .message(message)
+                .status("SUCCESS")
+                .build());
+            fcmService.sendPushNotification(guardian.getFcmToken(), fcmTitle, message, notificationType);
+        }
     }
 
     // 보호자 ID로 담당 피보호자 전체의 해결/미해결 이벤트 수를 집계하여 반환
@@ -90,7 +284,7 @@ public class EmergencyEventService {
         return new EventSummaryResponse(resolvedCount, unresolvedCount);
     }
 
-    // 보호자 ID로 담당 피보호자 전체의 응급 이벤트 목록을 최신순으로 조회 (이벤트 타입별 상세 설명 포함)
+    // 보호자 ID로 담당 피보호자 전체의 응급 이벤트 목록을 최신순으로 조회
     @Transactional(readOnly = true)
     public EmergencyAlertListResponse getEmergencyAlertsForGuardian(Long guardianId) {
         Guardian guardian = guardianRepository.findById(guardianId)
@@ -116,7 +310,7 @@ public class EmergencyEventService {
         return new EmergencyAlertListResponse(alerts);
     }
 
-    // 특정 이벤트를 RESOLVED로 변경 — 해당 보호자가 담당하는 피보호자의 이벤트인지 권한 검증 후 처리
+    // 특정 이벤트를 RESOLVED로 변경 — 권한 검증 후 처리
     @Transactional
     public ResponseEvent resolveEvent(Long guardianId, Long eventId) {
         Guardian guardian = guardianRepository.findById(guardianId)
@@ -135,12 +329,18 @@ public class EmergencyEventService {
 
         if (!"RESOLVED".equals(event.getStatus())) {
             event.updateStatus("RESOLVED");
+            fcmService.sendPushNotification(
+                guardian.getFcmToken(),
+                "응급 상황 해결",
+                event.getUser().getName() + "님의 응급 상황이 해결되었습니다.",
+                "ALERT"
+            );
         }
 
         return new ResponseEvent(event.getId(), event.getEventType(), event.getStatus(), event.getCreatedAt());
     }
 
-    // 보호자 ID로 담당 피보호자 전체의 PENDING 이벤트를 한 번에 RESOLVED로 일괄 처리
+    // 보호자 ID로 담당 피보호자 전체의 PENDING 이벤트를 일괄 RESOLVED 처리
     @Transactional
     public void resolveAllEvents(Long guardianId) {
         Guardian guardian = guardianRepository.findById(guardianId)
@@ -154,9 +354,18 @@ public class EmergencyEventService {
 
         emergencyEventRepository.findByUserInAndStatus(users, "PENDING")
             .forEach(event -> event.updateStatus("RESOLVED"));
+
+        users.forEach(user ->
+            fcmService.sendPushNotification(
+                guardian.getFcmToken(),
+                "응급 상황 해결",
+                user.getName() + "님의 모든 응급 상황이 해결되었습니다.",
+                "ALERT"
+            )
+        );
     }
 
-    // 피보호자 ID로 가장 최근 PENDING 이벤트 1건 조회 — 없으면 null 반환 (앱 팝업 표시 여부 판단용)
+    // 피보호자 ID로 가장 최근 PENDING 이벤트 1건 조회
     @Transactional(readOnly = true)
     public ResponseEvent getLatestPendingEvent(long userId) {
         Users user = userRepository.findById(userId)

--- a/src/main/java/com/ikongserver/service/FcmService.java
+++ b/src/main/java/com/ikongserver/service/FcmService.java
@@ -1,0 +1,40 @@
+package com.ikongserver.service;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class FcmService {
+
+    // FCM 푸시 알림 전송 — notificationType으로 앱에서 일반/긴급 알림 화면 구분
+    // notificationType: "ALERT"(주의) or "EMERGENCY"(심각/낙상)
+    public void sendPushNotification(String fcmToken, String title, String body, String notificationType) {
+        if (fcmToken == null || fcmToken.isBlank()) {
+            return;
+        }
+        if (FirebaseApp.getApps().isEmpty()) {
+            log.warn("Firebase 미초기화 상태 — FCM 발송 건너뜀: {}", title);
+            return;
+        }
+        try {
+            Message message = Message.builder()
+                .setToken(fcmToken)
+                .setNotification(Notification.builder()
+                    .setTitle(title)
+                    .setBody(body)
+                    .build())
+                .putData("notificationType", notificationType)
+                .build();
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("FCM 발송 성공 [{}]: {}", notificationType, response);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 발송 실패: {}", e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ikongserver/service/GuardianService.java
+++ b/src/main/java/com/ikongserver/service/GuardianService.java
@@ -9,11 +9,13 @@ import com.ikongserver.repository.GuardianInvitationRepository;
 import com.ikongserver.repository.GuardianRepository;
 import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
+import lombok.extern.slf4j.Slf4j;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -25,6 +27,7 @@ public class GuardianService {
     private final GuardianInvitationRepository guardianInvitationRepository;
     private final UserGuardianMapRepository userGuardianMapRepository;
     private final UsersRepository usersRepository;
+    private final FcmService fcmService;
 
     // 보호자 직접 등록 — 최대 5명 제한 초과 시 예외 발생, Guardian + UserGuardianMap 동시 생성
     @Transactional
@@ -97,6 +100,16 @@ public class GuardianService {
             .build();
         guardianInvitationRepository.save(invitation);
 
+        // 초대받은 보호자가 이미 앱에 가입된 경우 FCM 알림 발송
+        guardianRepository.findByPhone(request.phone()).ifPresent(guardian -> {
+            fcmService.sendPushNotification(
+                guardian.getFcmToken(),
+                "보호자 초대",
+                user.getName() + "님이 보호자로 초대했습니다.",
+                "ALERT"
+            );
+        });
+
         return new GuardianDto.ResponseInvite(
             invitation.getId(),
             invitation.getName(),
@@ -108,20 +121,34 @@ public class GuardianService {
         );
     }
 
-    // 초대 수락 — GuardianInvitation status를 ACCEPTED로 변경 (중복 처리 방지는 entity에서 검증)
+    // 초대 수락 — GuardianInvitation status를 ACCEPTED로 변경, 피보호자에게 FCM 알림 발송
     @Transactional
     public void acceptInvitation(Long invitationId) {
         GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
             .orElseThrow(() -> new IllegalArgumentException("초대를 찾을 수 없습니다."));
         invitation.accept();
+
+        fcmService.sendPushNotification(
+            invitation.getUser().getFcmToken(),
+            "보호자 초대 수락",
+            invitation.getName() + "님이 보호자 초대를 수락했습니다.",
+            "ALERT"
+        );
     }
 
-    // 초대 거절 — GuardianInvitation status를 REJECTED로 변경 (중복 처리 방지는 entity에서 검증)
+    // 초대 거절 — GuardianInvitation status를 REJECTED로 변경, 피보호자에게 FCM 알림 발송
     @Transactional
     public void rejectInvitation(Long invitationId) {
         GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
             .orElseThrow(() -> new IllegalArgumentException("초대를 찾을 수 없습니다."));
         invitation.reject();
+
+        fcmService.sendPushNotification(
+            invitation.getUser().getFcmToken(),
+            "보호자 초대 거절",
+            invitation.getName() + "님이 보호자 초대를 거절했습니다.",
+            "ALERT"
+        );
     }
 
     // 보호자 삭제 — 실제 레코드 삭제 대신 UserGuardianMap의 isActive를 "N"으로 변경 (소프트 삭제)

--- a/src/main/java/com/ikongserver/service/GuardianService.java
+++ b/src/main/java/com/ikongserver/service/GuardianService.java
@@ -27,6 +27,7 @@ public class GuardianService {
     private final UserGuardianMapRepository userGuardianMapRepository;
     private final UsersRepository usersRepository;
 
+    // 보호자 직접 등록 — 최대 5명 제한 초과 시 예외 발생, Guardian + UserGuardianMap 동시 생성
     @Transactional
     public GuardianDto.ResponseRegister registerGuardian(Long userId, GuardianDto.RequestRegister request) {
         Users user = usersRepository.findById(userId)
@@ -64,6 +65,7 @@ public class GuardianService {
         );
     }
 
+    // 피보호자 ID로 등록된 보호자 목록 조회 (활성/비활성 포함)
     public List<GuardianDto.ResponseGuardian> getGuardians(Long userId) {
         Users user = usersRepository.findById(userId)
             .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
@@ -81,6 +83,7 @@ public class GuardianService {
             .toList();
     }
 
+    // 보호자 초대 발송 — GuardianInvitation 레코드 생성, 초대 수락 전까지 UserGuardianMap에 반영 안 됨
     @Transactional
     public GuardianDto.ResponseInvite inviteGuardian(Long userId, GuardianDto.RequestInvite request) {
         Users user = usersRepository.findById(userId)
@@ -106,6 +109,7 @@ public class GuardianService {
         );
     }
 
+    // 초대 수락 — status ACCEPTED로 변경 + UserGuardianMap 생성 (보호 관계 등록)
     @Transactional
     public void acceptInvitation(Long invitationId) {
         GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
@@ -131,6 +135,7 @@ public class GuardianService {
         }
     }
 
+    // 초대 거절 — GuardianInvitation status를 REJECTED로 변경 (중복 처리 방지는 entity에서 검증)
     @Transactional
     public void rejectInvitation(Long invitationId) {
         GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
@@ -155,6 +160,7 @@ public class GuardianService {
             .toList();
     }
 
+    // 보호자 삭제 — 실제 레코드 삭제 대신 UserGuardianMap의 isActive를 "N"으로 변경 (소프트 삭제)
     @Transactional
     public void deleteGuardian(Long userId, Long guardianId) {
         Users user = usersRepository.findById(userId)

--- a/src/main/java/com/ikongserver/service/GuardianService.java
+++ b/src/main/java/com/ikongserver/service/GuardianService.java
@@ -9,6 +9,7 @@ import com.ikongserver.repository.GuardianInvitationRepository;
 import com.ikongserver.repository.GuardianRepository;
 import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,7 +27,6 @@ public class GuardianService {
     private final UserGuardianMapRepository userGuardianMapRepository;
     private final UsersRepository usersRepository;
 
-    // 보호자 직접 등록 — 최대 5명 제한 초과 시 예외 발생, Guardian + UserGuardianMap 동시 생성
     @Transactional
     public GuardianDto.ResponseRegister registerGuardian(Long userId, GuardianDto.RequestRegister request) {
         Users user = usersRepository.findById(userId)
@@ -64,7 +64,6 @@ public class GuardianService {
         );
     }
 
-    // 피보호자 ID로 등록된 보호자 목록 조회 (활성/비활성 포함)
     public List<GuardianDto.ResponseGuardian> getGuardians(Long userId) {
         Users user = usersRepository.findById(userId)
             .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
@@ -82,7 +81,6 @@ public class GuardianService {
             .toList();
     }
 
-    // 보호자 초대 발송 — GuardianInvitation 레코드 생성, 초대 수락 전까지 UserGuardianMap에 반영 안 됨
     @Transactional
     public GuardianDto.ResponseInvite inviteGuardian(Long userId, GuardianDto.RequestInvite request) {
         Users user = usersRepository.findById(userId)
@@ -108,15 +106,31 @@ public class GuardianService {
         );
     }
 
-    // 초대 수락 — GuardianInvitation status를 ACCEPTED로 변경 (중복 처리 방지는 entity에서 검증)
     @Transactional
     public void acceptInvitation(Long invitationId) {
         GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
             .orElseThrow(() -> new IllegalArgumentException("초대를 찾을 수 없습니다."));
         invitation.accept();
+
+        Users user = invitation.getUser();
+        Guardian guardian = guardianRepository.findByPhone(invitation.getPhone())
+            .orElseThrow(() -> new IllegalArgumentException("보호자를 찾을 수 없습니다."));
+
+        boolean alreadyMapped = userGuardianMapRepository.existsByUserAndGuardian(user, guardian);
+        if (!alreadyMapped) {
+            long activeCount = userGuardianMapRepository.countByUserAndIsActive(user, "Y");
+            if (activeCount < MAX_GUARDIAN_COUNT) {
+                userGuardianMapRepository.save(UserGuardianMap.builder()
+                    .user(user)
+                    .guardian(guardian)
+                    .relation(invitation.getRelation())
+                    .isPrimary(invitation.getIsPrimary() ? "Y" : "N")
+                    .isActive("Y")
+                    .build());
+            }
+        }
     }
 
-    // 초대 거절 — GuardianInvitation status를 REJECTED로 변경 (중복 처리 방지는 entity에서 검증)
     @Transactional
     public void rejectInvitation(Long invitationId) {
         GuardianInvitation invitation = guardianInvitationRepository.findById(invitationId)
@@ -124,7 +138,23 @@ public class GuardianService {
         invitation.reject();
     }
 
-    // 보호자 삭제 — 실제 레코드 삭제 대신 UserGuardianMap의 isActive를 "N"으로 변경 (소프트 삭제)
+    public List<GuardianDto.PendingInvitationResponse> getPendingInvitations(Long guardianId) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+            .orElseThrow(() -> new IllegalArgumentException("보호자를 찾을 수 없습니다."));
+        if (guardian.getPhone() == null) return Collections.emptyList();
+        return guardianInvitationRepository
+            .findByPhoneAndStatus(guardian.getPhone(), "PENDING")
+            .stream()
+            .map(inv -> new GuardianDto.PendingInvitationResponse(
+                inv.getId(),
+                inv.getUser().getName(),
+                inv.getRelation(),
+                inv.getIsPrimary(),
+                inv.getCreatedAt()
+            ))
+            .toList();
+    }
+
     @Transactional
     public void deleteGuardian(Long userId, Long guardianId) {
         Users user = usersRepository.findById(userId)

--- a/src/main/java/com/ikongserver/service/KakaoAuthService.java
+++ b/src/main/java/com/ikongserver/service/KakaoAuthService.java
@@ -38,10 +38,11 @@ public class KakaoAuthService {
                 name = (String) profile.get("nickname");
             }
 
-            // 전화번호 (+82 10-xxxx-xxxx → 010-xxxx-xxxx)
+            // 전화번호 (+82 10-1234-5678 → 01012345678 숫자만)
             String rawPhone = (String) kakaoAccount.get("phone_number");
             if (rawPhone != null) {
-                phone = rawPhone.replace("+82 ", "0").replace("+82", "0");
+                phone = rawPhone.replace("+82 ", "0").replace("+82", "0")
+                        .replaceAll("[^0-9]", "");
             }
 
             // 생년 (birthyear만 수신 → YYYY-01-01)

--- a/src/main/java/com/ikongserver/service/NotificationService.java
+++ b/src/main/java/com/ikongserver/service/NotificationService.java
@@ -53,15 +53,15 @@ public class NotificationService {
             notification.getSentAt());
     }
 
-    // 보호자 ID 기준 알림 목록 조회 — status 파라미터가 있으면 상태 필터 적용, 없으면 전체 반환 (페이징)
+    // 보호자 ID 기준 알림 목록 조회 — eventStatus(PENDING/RESOLVED) 필터 지원, 없으면 전체 반환 (페이징)
     @Transactional(readOnly = true)
-    public NotificationListResponse getNotifications(Long guardianId, String status, int page,
+    public NotificationListResponse getNotifications(Long guardianId, String eventStatus, int page,
         int size) {
         Page<Notification> result;
 
-        if (status != null && !status.isEmpty()) {
-            result = notificationRepository.findByGuardianIdAndStatus(
-                guardianId, status, PageRequest.of(page - 1, size));
+        if (eventStatus != null && !eventStatus.isEmpty()) {
+            result = notificationRepository.findByGuardianIdAndEventStatus(
+                guardianId, eventStatus, PageRequest.of(page - 1, size));
         } else {
             result = notificationRepository.findByGuardianId(
                 guardianId, PageRequest.of(page - 1, size));
@@ -75,22 +75,22 @@ public class NotificationService {
                     n.getEmergencyEvent().getUser().getName(),
                     n.getEmergencyEvent().getEventType(),
                     n.getMessage(),
-                    n.getStatus(),
+                    n.getEmergencyEvent().getStatus(),
                     n.getSentAt(),
                     n.getReadYN()))
                 .toList()
         );
     }
 
-    // 피보호자 ID 기준 알림 목록 조회 — 본인과 연결된 응급 이벤트의 알림만 반환 (페이징)
+    // 피보호자 ID 기준 알림 목록 조회 — eventStatus(PENDING/RESOLVED) 필터 지원, 없으면 전체 반환 (페이징)
     @Transactional(readOnly = true)
-    public NotificationListResponse getNotificationsByUserId(Long userId, String status, int page,
+    public NotificationListResponse getNotificationsByUserId(Long userId, String eventStatus, int page,
         int size) {
         Page<Notification> result;
 
-        if (status != null && !status.isEmpty()) {
-            result = notificationRepository.findByUserIdAndStatus(
-                userId, status, PageRequest.of(page - 1, size));
+        if (eventStatus != null && !eventStatus.isEmpty()) {
+            result = notificationRepository.findByUserIdAndEventStatus(
+                userId, eventStatus, PageRequest.of(page - 1, size));
         } else {
             result = notificationRepository.findByUserId(
                 userId, PageRequest.of(page - 1, size));
@@ -104,7 +104,7 @@ public class NotificationService {
                     n.getEmergencyEvent().getUser().getName(),
                     n.getEmergencyEvent().getEventType(),
                     n.getMessage(),
-                    n.getStatus(),
+                    n.getEmergencyEvent().getStatus(),
                     n.getSentAt(),
                     n.getReadYN()))
                 .toList()
@@ -122,6 +122,14 @@ public class NotificationService {
         Notification notification = notificationRepository.findById(notificationId)
             .orElseThrow(() -> new RuntimeException("알림을 찾을 수 없습니다."));
         notification.updateReadYN("Y");
+    }
+
+    // 보호자 FCM 토큰 저장/갱신 — 앱 실행 시 최신 토큰을 서버에 등록
+    @Transactional
+    public void updateFcmToken(Long guardianId, String fcmToken) {
+        Guardian guardian = guardianRepository.findById(guardianId)
+            .orElseThrow(() -> new RuntimeException("보호자를 찾을 수 없습니다."));
+        guardian.updateFcmToken(fcmToken);
     }
 
     // 긴급 알림 디테일 상황

--- a/src/main/java/com/ikongserver/service/UserService.java
+++ b/src/main/java/com/ikongserver/service/UserService.java
@@ -23,6 +23,13 @@ public class UserService {
     private final UserGuardianMapRepository userGuardianMapRepository;
     private final VitalRepository vitalRepository;
 
+    @Transactional
+    public void updateFcmToken(Long userId, String fcmToken) {
+        Users user = userRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+        user.updateFcmToken(fcmToken);
+    }
+
     public MainProfileResponse getMainProfile(Long userId) {
 
         // 피보호자 아이디 조회 및 예외 처리

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=iKong-server
-spring.profiles.active=dev
+spring.profiles.active=main


### PR DESCRIPTION
## 변경 사항
- 알림 내역 조회 및 관리 API 구현
-  Firebase FCM 기반 긴급 알림 / 일반 알림 구현

## 작업 내용

**긴급 알림 (EMERGENCY) — 보호자에게 발송**
| 상황 | 트리거 |
|------|--------|
| 낙상 감지 | 생체 데이터 수신 즉시 |
| 심박수 이상 [주의] | 30초 연속 이상 |
| 심박수 위험 [심각] | 60초 연속 이상 (이후 5분마다 재알림) |
| 호흡수 이상 [주의] | 30초 연속 이상 |
| 호흡수 위험 [심각] | 60초 연속 이상 (이후 5분마다 재알림) |

**일반 알림 (ALERT)**
| 상황 | 수신자 |
|------|--------|
| 기기 연결 끊김 (10분 이상) | 보호자 |
| 응급 상황 해결 처리 | 보호자 |
| 보호자 초대 수락 | 피보호자 |
| 보호자 초대 거절 | 피보호자 |

**FCM 푸시 알림**
- FcmService: Firebase Admin SDK로 FCM 메시지 발송
- 긴급 이벤트 발생 시 담당 보호자에게 FCM 긴급 알림 발송 (EMERGENCY)
- 기기 연결 끊김 감지 시 보호자에게 FCM 알림 발송 (ALERT, 30분 쿨다운)
- 보호자 초대 수락/거절 시 피보호자에게 FCM 알림 발송
- 피보호자 FCM 토큰 등록 API 추가 (PUT /api/users/fcm-token)

**알림 내역**
- 보호자/피보호자 기준 알림 목록 조회 API (GET /api/notifications)
- PENDING/RESOLVED 상태 필터링 지원 (EmergencyEvent.status 기준)
- 알림 읽음 처리 API (PATCH /api/notifications/{id}/read)
- 읽지 않은 알림 수 조회 API (GET /api/notifications/unread-count)
- 긴급 알림 상세 조회 API (GET /api/emergency_event/{id}/detail)

**버그 수정**
- 알림 필터 버그 수정: Notification.status → EmergencyEvent.status 기준으로 변경
- DeviceMonitorService LazyInitializationException 수정 (@Transactional 추가)
- UserGuardianMapRepository 잘못된 JPA 메서드 제거

## 테스트
- Thunder Client로 알림 목록 조회, 읽음 처리, FCM 토큰 등록, 긴급 알림 상세 API 확인
- 서버 실행 후 스케줄러 정상 동작 확인

## 참고 사항
- firebase-service-account.json은 .gitignore에 추가됨 (커밋 제외)
- FCM notificationType: EMERGENCY(긴급 알림), ALERT(일반 알림)"