### PR TITLE
Dev

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     // FCM
-    implementation 'com.google.firebase:firebase-admin:9.2.0'
+    implementation 'com.google.firebase:firebase-admin:9.3.0'
     // 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/com/ikongserver/service/VitalService.java
+++ b/src/main/java/com/ikongserver/service/VitalService.java
@@ -7,6 +7,10 @@ import com.ikongserver.entity.Users;
 import com.ikongserver.entity.Vital;
 import com.ikongserver.repository.DeviceRepository;
 import com.ikongserver.repository.VitalRepository;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.RequiredArgsConstructor;
@@ -39,8 +43,8 @@ public class VitalService {
         Users user = device.getUser();
 
         // 데이터 안정화 (알고리즘 필터 통과)
-        int stabilizedHR = filterNoise_HR(vitalDto.heartRate());
-        int stabilizedBR = filterNoise_BR(vitalDto.breathRate());
+        int stabilizedHR = filterNoise_HR(vitalDto.serialNum(), vitalDto.heartRate());
+        int stabilizedBR = filterNoise_BR(vitalDto.serialNum(), vitalDto.breathRate());
 
         // 긴급 상황 검사 및 상태 반환
         boolean status = false;
@@ -74,13 +78,60 @@ public class VitalService {
         }
     }
 
-    // --- 데이터 안정화 알고리즘 더미 (추후 로직 채워넣을 예정) ---
-    private int filterNoise_HR(int rawHeartRate) {
-        return rawHeartRate; // 일단 들어온 값 그대로 반환
+    // 💡 1차 검사관 (Median): 문서 명세에 따라 윈도우 사이즈 3 (약 6초 분량 데이터)
+    private static final int WINDOW_SIZE = 3;
+    private final Map<String, LinkedList<Integer>> hrWindowMap = new ConcurrentHashMap<>();
+    private final Map<String, LinkedList<Integer>> brWindowMap = new ConcurrentHashMap<>();
+
+    // 💡 2차 검사관 (EMA): 문서 권장값 (0.3 ~ 0.4 사이의 최적값 0.35 적용)
+    // 너무 낮으면(0.1) 10~20초 지연이 발생하므로 0.35가 가장 적절합니다.
+    private static final double EMA_ALPHA = 0.35;
+    private final Map<String, Integer> lastEmaHrMap = new ConcurrentHashMap<>();
+    private final Map<String, Integer> lastEmaBrMap = new ConcurrentHashMap<>();
+
+    // --- 🛠️ 명세서 기반 하이브리드 안정화 알고리즘 (Median + EMA) ---
+
+    private int filterNoise_HR(String serialNum, int rawHeartRate) {
+        return applyHybridFilter(serialNum, rawHeartRate, hrWindowMap, lastEmaHrMap);
     }
 
-    private int filterNoise_BR(int rawBreathRate) {
-        return rawBreathRate; // 일단 들어온 값 그대로 반환
+    private int filterNoise_BR(String serialNum, int rawBreathRate) {
+        return applyHybridFilter(serialNum, rawBreathRate, brWindowMap, lastEmaBrMap);
+    }
+
+    // 공통 필터 로직
+    private int applyHybridFilter(String serialNum, int rawValue,
+        Map<String, LinkedList<Integer>> windowMap,
+        Map<String, Integer> emaMap) {
+
+        // 1. 기기별 윈도우 바구니 가져오기
+        LinkedList<Integer> window = windowMap.computeIfAbsent(serialNum, k -> new LinkedList<>());
+
+        // 2. 새 데이터 추가 및 오래된 데이터 제거 (최대 3개 유지)
+        window.add(rawValue);
+        if (window.size() > WINDOW_SIZE) {
+            window.removeFirst();
+        }
+
+        // 3. 데이터가 3개 미만일 때는 초기화 과정이므로 원본 반환
+        if (window.size() < WINDOW_SIZE) {
+            emaMap.put(serialNum, rawValue);
+            return rawValue;
+        }
+
+        // 4. [Median Filter] 3개 데이터 중 중간값 추출 (Pi가 놓친 미세 스파이크 최종 방어)
+        List<Integer> sortedWindow = new ArrayList<>(window);
+        Collections.sort(sortedWindow);
+        int medianValue = sortedWindow.get(WINDOW_SIZE / 2);
+
+        // 5. [EMA Filter] 이전 평균값과 현재 중간값을 가중치(0.35)로 결합 (유일한 스무딩 단계)
+        int lastEma = emaMap.getOrDefault(serialNum, medianValue);
+        int finalSmoothedValue = (int) Math.round((medianValue * EMA_ALPHA) + (lastEma * (1.0 - EMA_ALPHA)));
+
+        // 6. 계산된 최종 값을 EMA 장부에 기록
+        emaMap.put(serialNum, finalSmoothedValue);
+
+        return finalSmoothedValue;
     }
 
 }


### PR DESCRIPTION
🚨 문제 상황: IoT 센서의 한계라즈베리파이에 연결된 mmWave 센서는 비접촉식이기 때문에, 피보호자가 기침을 크게 하거나 몸을 뒤척이면 순간적으로 심박수가 70 ➡️ 150 ➡️ 71처럼 미친 듯이 튀어버리는 '스파이크(Spike) 노이즈'가 발생합니다. 이걸 그대로 프론트엔드로 보내면 1초 만에 응급 알람이 울리는 대참사가 일어납니다.이 노이즈를 완벽하게 잡기 위해 우리는 두 명의 검사관을 배치했습니다.

🛡️ 1차 검사관: 중간값 필터 (Median Filter)역할: 물리적으로 불가능한 '튀는 값(Spike)'을 아예 잘라내어 버림평균(Average)을 내지 않고 중간값(Median)을 사용하는 것이 핵심입니다. 평균은 극단적인 값에 쉽게 오염되지만, 중간값은 극단적인 값을 무시하는 성질이 있습니다.슬라이딩 윈도우 (Sliding Window): 최근 들어온 데이터 딱 3개(WINDOW_SIZE = 3)만 담을 수 있는 움직이는 바구니를 만듭니다.정렬 및 추출: 바구니 안의 3개 숫자를 크기순으로 나열하고, 가운데 있는 숫자만 통과시킵니다

📊 시나리오: 정상 심박수 70, 71이 들어오다 갑자기 150(노이즈)이 들어왔을 때바구니 상태: [70, 150, 71]크기순 정렬: [70, 71, 150]중간값 추출: 71 (통과!)결과: 평균을 냈다면 97이 되어 그래프가 튀었겠지만, 중간값을 쓰니 150이라는 노이즈가 마법처럼 흔적도 없이 사라졌습니다.
🌊 2차 검사관: 지수 이동 평균 (EMA, Exponential Moving Average)역할: 데이터를 부드럽게 이어주어(Smoothing) 자연스러운 그래프를 만듦1차 검사관이 노이즈를 제거해 줬지만, 데이터가 여전히 딱딱하게 끊길 수 있습니다. 이를 부드럽게 만들기 위해 EMA 알고리즘을 사용합니다. EMA는 "과거의 기억과 새로운 현실을 적절한 비율로 섞는 방식"입니다.이때 섞는 비율을 알파($\alpha$)라고 부르며, 명세서에 따라 우리는 $0.35$ (35%)로 설정했습니다.수학 공식:$$EMA_{current} = (Value_{new} \times \alpha) + (EMA_{previous} \times (1 - \alpha))$$

📊 시나리오: 직전까지의 안정된 심박수(과거 기억)가 70이었고, 방금 1차 검사관을 통과한 새로운 데이터가 75일 때 ($\alpha = 0.35$)새로운 데이터의 지분 (35%): $75 \times 0.35 = 26.25$과거 기억의 지분 (65%): $70 \times 0.65 = 45.5$최종 심박수: $26.25 + 45.5 = 71.75 \approx$ 72 (소수점 반올림)결과: 값이 갑자기 70에서 75로 훅 뛰지 않고, 72로 부드럽게 계단을 오르듯 상승합니다.✨ 요약: 왜 이 두 개의 조합이 완벽한가?만약 EMA만 썼다면: 150이라는 엄청난 노이즈가 들어왔을 때, 가중치에 의해 그래프가 위로 확 끌려 올라가서 한동안 내려오지 않는 '꼬리 끌림' 현상이 발생합니다.만약 중간값(Median)만 썼다면: 튀는 값은 잡겠지만, 그래프가 부드럽지 않고 뚝뚝 끊기며 각진 형태로 그려집니다.