### PR TITLE
feat: 센서 시리얼 분기·워밍업 제외·VITAL_ISSUE 3분 쿨다운 적용

### DIFF
--- a/src/main/java/com/ikongserver/repository/VitalRepository.java
+++ b/src/main/java/com/ikongserver/repository/VitalRepository.java
@@ -26,6 +26,9 @@ public interface VitalRepository extends JpaRepository<Vital, Long> {
     // 개인 기준선 계산용: 기간 내 vital 목록
     List<Vital> findByUserAndRecordedAtAfter(Users user, LocalDateTime from);
 
+    // 워밍업 제외용: 피보호자의 가장 오래된 vital 10건 (recordedAt 오름차순)
+    List<Vital> findTop10ByUserOrderByRecordedAtAsc(Users user);
+
     // [오늘] 시간별 심박수 평균/최소/최대 — 결과: [hour, avg, min, max]
     @Query(value = """
         SELECT EXTRACT(HOUR FROM recorded_at)::int AS hour,

--- a/src/main/java/com/ikongserver/service/EmergencyEventService.java
+++ b/src/main/java/com/ikongserver/service/EmergencyEventService.java
@@ -48,6 +48,13 @@ public class EmergencyEventService {
     // 개인 기준선 가중치 반감기 — 데이터가 이만큼 오래될수록 가중치 절반 (1일)
     private static final long BASELINE_HALF_LIFE_MS = 24 * 60 * 60 * 1000L;
 
+    // 워밍업 데이터 수 — 사용자 최초 N건은 기준선 계산에서 제외 (센서 초기 이상값 차단)
+    private static final int BASELINE_WARMUP_COUNT = 10;
+
+    // VITAL_ISSUE 생성 쿨다운 — 동일 시리얼 번호당 3분 (중복 응급 이벤트 방지)
+    private static final long VITAL_ANOMALY_COOLDOWN_MS = 3 * 60 * 1000L;
+    private final Map<String, Long> lastVitalAnomalyTimeMap = new ConcurrentHashMap<>();
+
     // 개인 기준선 캐시 — 6시간마다 재계산 (매초 DB 조회 방지)
     private static final long BASELINE_CACHE_TTL = 6 * 60 * 60 * 1000L;
     private final Map<Long, int[]> baselineCache = new ConcurrentHashMap<>();
@@ -176,12 +183,13 @@ public class EmergencyEventService {
         boolean brBad = brCount >= ABNORMAL_CONSECUTIVE;
 
         // 이상 지표 개수로 심각도 결정 — 양쪽 동시 이상이면 CRITICAL, 한쪽만이면 WARNING
+        String serialNum = vitalDto.serialNum();
         if (hrBad && brBad) {
-            return handleCondition(user, device, "CRITICAL", "VITAL_ISSUE");
+            return handleCondition(user, device, "CRITICAL", "VITAL_ISSUE", serialNum);
         } else if (hrBad) {
-            return handleCondition(user, device, "WARNING", "HEART_ISSUE");
+            return handleCondition(user, device, "WARNING", "HEART_ISSUE", serialNum);
         } else if (brBad) {
-            return handleCondition(user, device, "WARNING", "BREATH_ISSUE");
+            return handleCondition(user, device, "WARNING", "BREATH_ISSUE", serialNum);
         }
 
         // 양쪽 다 30초 미달 — 이상 없음, 진행 중 episode 종료
@@ -190,7 +198,9 @@ public class EmergencyEventService {
     }
 
     // 이상 상태 처리 — 신규 발생/악화 시 새 이벤트+알림, 지속 시 1분마다 미확인 보호자에게만 재알림
-    private boolean handleCondition(Users user, Device device, String severity, String eventType) {
+    // VITAL_ISSUE는 동일 시리얼 번호당 3분 쿨다운으로 중복 생성 방지
+    private boolean handleCondition(Users user, Device device, String severity, String eventType,
+        String serialNum) {
         Long userId = user.getId();
         Episode active = activeEpisodeMap.get(userId);
         long now = System.currentTimeMillis();
@@ -200,6 +210,15 @@ public class EmergencyEventService {
             && "WARNING".equals(active.severity) && "CRITICAL".equals(severity);
 
         if (isNew || isEscalation) {
+            // VITAL_ISSUE는 동일 serialNum 3분 쿨다운 적용 — 쿨다운 중이면 이벤트 생성/알림 발송 생략
+            if ("VITAL_ISSUE".equals(eventType) && serialNum != null) {
+                Long lastTime = lastVitalAnomalyTimeMap.get(serialNum);
+                if (lastTime != null && now - lastTime < VITAL_ANOMALY_COOLDOWN_MS) {
+                    return true; // 쿨다운 중 — 긴급 상태만 유지하고 새 이벤트는 만들지 않음
+                }
+                lastVitalAnomalyTimeMap.put(serialNum, now);
+            }
+
             // 신규 발생 또는 WARNING→CRITICAL 악화 — 새 이벤트 생성 + 보호자 전원 알림
             EmergencyEvent event = EmergencyEvent.builder()
                 .user(user).eventType(eventType).status("PENDING")
@@ -257,7 +276,8 @@ public class EmergencyEventService {
 
     // 개인 기준선(가중평균) 반환 — 캐시 유효하면 재사용, 만료 시 재계산
     // 최근 데이터일수록 가중치를 크게 두는 지수 시간감쇠 가중평균으로 계산
-    // 데이터가 1건도 없으면 null 반환 → 고령자 표준 임계값 사용
+    // 사용자 최초 BASELINE_WARMUP_COUNT건은 센서 초기 이상값으로 보고 계산에서 제외
+    // 워밍업 미완료(총 데이터 < N건)이거나 워밍업 이후 가용 데이터가 없으면 null 반환 → 고령자 표준 임계값 사용
     private int[] getPersonalBaseline(Users user) {
         Long userId = user.getId();
         Long lastCalc = baselineCacheTime.get(userId);
@@ -268,8 +288,18 @@ public class EmergencyEventService {
             return baselineCache.get(userId);
         }
 
-        List<Vital> vitals = vitalRepository.findByUserAndRecordedAtAfter(
+        // 워밍업: 사용자의 가장 오래된 10건의 마지막 시각을 구해 그 이전 데이터는 제외
+        List<Vital> earliest = vitalRepository.findTop10ByUserOrderByRecordedAtAsc(user);
+        if (earliest.size() < BASELINE_WARMUP_COUNT) {
+            return null; // 워밍업 단계 — 기준선 신뢰 불가, 표준값 사용
+        }
+        LocalDateTime warmupEnd = earliest.get(BASELINE_WARMUP_COUNT - 1).getRecordedAt();
+
+        List<Vital> windowVitals = vitalRepository.findByUserAndRecordedAtAfter(
             user, LocalDateTime.now().minusDays(BASELINE_WINDOW_DAYS));
+        List<Vital> vitals = windowVitals.stream()
+            .filter(v -> v.getRecordedAt().isAfter(warmupEnd))
+            .toList();
         if (vitals.isEmpty()) {
             return null;
         }

--- a/src/main/java/com/ikongserver/service/VitalService.java
+++ b/src/main/java/com/ikongserver/service/VitalService.java
@@ -33,8 +33,10 @@ public class VitalService {
 
     @Transactional
     public void getVitalData(VitalRequestDto vitalDto) {
+        String serialNum = vitalDto.serialNum();
+
         // 라즈베리와 연결이 되어 있는지 확인
-        Device device = deviceRepository.findBySerialNum(vitalDto.serialNum())
+        Device device = deviceRepository.findBySerialNum(serialNum)
             .orElseThrow(() -> new IllegalArgumentException("기기를 찾을 수 없습니다."));
         // 매초 마다 업데이트 되는 데이터를 device 테이블 안에서는 1분마다 연결 되어 있다는 마지막 연결 시간을 업데이트 함.
         device.updateLastConnectedAt();
@@ -42,26 +44,28 @@ public class VitalService {
         // 디바이스에서 피보호자 객체 찾기
         Users user = device.getUser();
 
+        // 센서 종류 분기 — 시리얼 접두사 기준 (FALL-*: 낙상 전용 / HR-* 등: 심박·호흡 전용)
+        if (serialNum != null && serialNum.startsWith("FALL")) {
+            // 낙상 센서: 낙상 감지만 수행하고 HR/BR/SSE/저장은 건너뜀
+            emergencyEventService.checkFallEvent(vitalDto, user, device);
+            return;
+        }
+
+        // HR-* 센서 (또는 미지정 시리얼): 심박·호흡 처리만 수행, 낙상 검사는 생략
         // 데이터 안정화 (알고리즘 필터 통과)
-        int stabilizedHR = filterNoise_HR(vitalDto.serialNum(), vitalDto.heartRate());
-        int stabilizedBR = filterNoise_BR(vitalDto.serialNum(), vitalDto.breathRate());
+        int stabilizedHR = filterNoise_HR(serialNum, vitalDto.heartRate());
+        int stabilizedBR = filterNoise_BR(serialNum, vitalDto.breathRate());
 
         // 긴급 상황 검사 및 상태 반환
-        boolean status = false;
-        boolean isFallEvent = emergencyEventService.checkFallEvent(vitalDto, user, device);
         boolean isHREvent = emergencyEventService.checkHeartBreathEvent(vitalDto, user, device);
-
-        if (isFallEvent || isHREvent) {
-            status = true;
-        }
 
         // 프론트엔드로 실시간 SSE 전송
         ResponseUserVital sseData = new ResponseUserVital(user.getId(), stabilizedHR, stabilizedBR,
-            status);
+            isHREvent);
         sseService.sendVitalDataToClient(user.getId(), sseData);
 
         long currentTime = System.currentTimeMillis();
-        long lastSavedTime = lastSavedTimeMap.getOrDefault(vitalDto.serialNum(), 0L);
+        long lastSavedTime = lastSavedTimeMap.getOrDefault(serialNum, 0L);
 
         // 받은 데이터를 Vital 테이블에 저장
         if (currentTime - lastSavedTime >= 10000) {
@@ -70,11 +74,11 @@ public class VitalService {
                 .device(device)
                 .heartRate(stabilizedHR)
                 .breathRate(stabilizedBR)
-                .isFallDetected(status)
+                .isFallDetected(false) // HR 센서는 낙상 정보 없음
                 .isPresent(vitalDto.isPresent())
                 .build();
             vitalRepository.save(newVital);
-            lastSavedTimeMap.put(vitalDto.serialNum(), currentTime);
+            lastSavedTimeMap.put(serialNum, currentTime);
         }
     }
 


### PR DESCRIPTION
feat: 센서 시리얼 분기·워밍업 제외·VITAL_ISSUE 3분 쿨다운 적용

- VitalService: serialNum 접두사로 분기
  · FALL-* → 낙상 감지만 수행 (HR/BR/SSE/저장 건너뜀)
  · HR-* 등 → 심박/호흡 처리만 수행 (낙상 검사 생략)
- EmergencyEventService: 개인 기준선 계산에서 사용자 최초 10건(워밍업) 제외
  · 총 데이터 10건 미만이면 워밍업 단계로 보고 고령자 표준값 사용
- EmergencyEventService: VITAL_ISSUE 이벤트에 동일 serialNum 3분 쿨다운 적용
  · 단일 지표(HEART_ISSUE/BREATH_ISSUE) 이벤트에는 영향 없음
- VitalRepository: 워밍업 조회용 findTop10ByUserOrderByRecordedAtAsc 메서드 추가