### PR TITLE
feat:질병 맞춤 알림 임계값 기능 구현

### DIFF
--- a/src/main/java/com/ikongserver/controller/UserConditionController.java
+++ b/src/main/java/com/ikongserver/controller/UserConditionController.java
@@ -1,0 +1,39 @@
+package com.ikongserver.controller;
+
+import com.ikongserver.dto.UserConditionDto.ConditionsResponse;
+import com.ikongserver.dto.UserConditionDto.UpdateConditionsRequest;
+import com.ikongserver.service.UserConditionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/users/conditions")
+public class UserConditionController {
+
+    private final UserConditionService userConditionService;
+
+    // 현재 등록된 질환 목록 조회
+    @GetMapping
+    public ResponseEntity<ConditionsResponse> getConditions(
+        @AuthenticationPrincipal UserDetails userDetails) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return ResponseEntity.ok(userConditionService.getConditions(userId));
+    }
+
+    // 질환 목록 등록/수정/삭제 — 빈 리스트 전송 시 전체 삭제
+    @PutMapping
+    public ResponseEntity<ConditionsResponse> updateConditions(
+        @AuthenticationPrincipal UserDetails userDetails,
+        @RequestBody UpdateConditionsRequest request) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        return ResponseEntity.ok(userConditionService.updateConditions(userId, request));
+    }
+}

--- a/src/main/java/com/ikongserver/dto/UserConditionDto.java
+++ b/src/main/java/com/ikongserver/dto/UserConditionDto.java
@@ -1,0 +1,17 @@
+package com.ikongserver.dto;
+
+import com.ikongserver.entity.ConditionType;
+import java.util.List;
+
+public class UserConditionDto {
+
+    // 질환 목록 등록/수정 요청 — conditions가 빈 리스트이면 전체 삭제
+    public record UpdateConditionsRequest(List<ConditionType> conditions) {
+
+    }
+
+    // 현재 등록된 질환 목록 응답
+    public record ConditionsResponse(List<ConditionType> conditions) {
+
+    }
+}

--- a/src/main/java/com/ikongserver/entity/ConditionType.java
+++ b/src/main/java/com/ikongserver/entity/ConditionType.java
@@ -1,0 +1,34 @@
+package com.ikongserver.entity;
+
+public enum ConditionType {
+
+    //               hrWarnHigh, hrCritHigh, hrWarnLow, hrCritLow, brWarnHigh, brCritHigh, requireBoth
+    HEART_ATTACK(   100,        120,        null,      null,      20,         25,         false), // 심근경색·허혈성 심장병 — 즉시 위험, 임계값만으로 판정
+    HEART_FAILURE(  90,         110,        50,        45,        20,         25,         true),  // 심부전 — 기준선 병행 확인
+    PNEUMONIA(      90,         110,        null,      null,      22,         26,         true),  // 폐렴 — 기준선 병행 확인
+    STROKE(         110,        120,        45,        40,        20,         25,         false), // 뇌졸중 — 즉시 위험, 임계값만으로 판정
+    COPD(           null,       null,       null,      null,      20,         25,         true),  // 만성폐쇄성폐질환 — 기준선 병행 확인 (HR은 베이스라인 비율 적용)
+    SEPSIS(         90,         110,        null,      null,      22,         26,         false), // 패혈증 — 즉시 위험, 임계값만으로 판정
+    ARRHYTHMIA(     130,        150,        45,        40,        20,         25,         true);  // 부정맥 — 기준선 병행 확인
+
+    public final Integer hrWarnHigh;
+    public final Integer hrCritHigh;
+    public final Integer hrWarnLow;
+    public final Integer hrCritLow;
+    public final Integer brWarnHigh;
+    public final Integer brCritHigh;
+    public final boolean requireBoth; // true: 질병 임계값 AND 기준선 둘 다 초과해야 이상, false: 임계값만 초과해도 이상
+
+    ConditionType(Integer hrWarnHigh, Integer hrCritHigh,
+                  Integer hrWarnLow, Integer hrCritLow,
+                  Integer brWarnHigh, Integer brCritHigh,
+                  boolean requireBoth) {
+        this.hrWarnHigh  = hrWarnHigh;
+        this.hrCritHigh  = hrCritHigh;
+        this.hrWarnLow   = hrWarnLow;
+        this.hrCritLow   = hrCritLow;
+        this.brWarnHigh  = brWarnHigh;
+        this.brCritHigh  = brCritHigh;
+        this.requireBoth = requireBoth;
+    }
+}

--- a/src/main/java/com/ikongserver/entity/UserCondition.java
+++ b/src/main/java/com/ikongserver/entity/UserCondition.java
@@ -1,0 +1,51 @@
+package com.ikongserver.entity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "user_condition",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "condition_type"}))
+public class UserCondition {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "condition_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "condition_type", nullable = false)
+    private ConditionType conditionType;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public UserCondition(Users user, ConditionType conditionType) {
+        this.user = user;
+        this.conditionType = conditionType;
+    }
+}

--- a/src/main/java/com/ikongserver/repository/UserConditionRepository.java
+++ b/src/main/java/com/ikongserver/repository/UserConditionRepository.java
@@ -1,0 +1,18 @@
+package com.ikongserver.repository;
+
+import com.ikongserver.entity.ConditionType;
+import com.ikongserver.entity.UserCondition;
+import com.ikongserver.entity.Users;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserConditionRepository extends JpaRepository<UserCondition, Long> {
+
+    List<UserCondition> findByUser(Users user);
+
+    void deleteByUserAndConditionType(Users user, ConditionType conditionType);
+
+    void deleteByUser(Users user);
+
+    boolean existsByUserAndConditionType(Users user, ConditionType conditionType);
+}

--- a/src/main/java/com/ikongserver/service/EmergencyEventService.java
+++ b/src/main/java/com/ikongserver/service/EmergencyEventService.java
@@ -5,10 +5,12 @@ import com.ikongserver.dto.EventDto.EmergencyAlertResponse;
 import com.ikongserver.dto.EventDto.EventSummaryResponse;
 import com.ikongserver.dto.EventDto.ResponseEvent;
 import com.ikongserver.dto.VitalDto.VitalRequestDto;
+import com.ikongserver.entity.ConditionType;
 import com.ikongserver.entity.Device;
 import com.ikongserver.entity.EmergencyEvent;
 import com.ikongserver.entity.Guardian;
 import com.ikongserver.entity.Notification;
+import com.ikongserver.entity.UserCondition;
 import com.ikongserver.entity.UserGuardianMap;
 import com.ikongserver.entity.Users;
 import com.ikongserver.entity.Vital;
@@ -16,6 +18,7 @@ import com.ikongserver.repository.DeviceRepository;
 import com.ikongserver.repository.EmergencyEventRepository;
 import com.ikongserver.repository.GuardianRepository;
 import com.ikongserver.repository.NotificationRepository;
+import com.ikongserver.repository.UserConditionRepository;
 import com.ikongserver.repository.UserGuardianMapRepository;
 import com.ikongserver.repository.UsersRepository;
 import com.ikongserver.repository.VitalRepository;
@@ -98,6 +101,7 @@ public class EmergencyEventService {
     private final NotificationRepository notificationRepository;
     private final VitalRepository vitalRepository;
     private final DeviceRepository deviceRepository;
+    private final UserConditionRepository userConditionRepository;
     private final FcmService fcmService;
 
     /**
@@ -163,16 +167,21 @@ public class EmergencyEventService {
         Long userId = user.getId();
         int[] baseline = getPersonalBaseline(user);
 
+        // 질환 목록 1회 조회 — HR/BR 판정에 재사용
+        List<ConditionType> conditions = userConditionRepository.findByUser(user).stream()
+            .map(uc -> uc.getConditionType())
+            .toList();
+
         // 연속 이상 카운터 갱신 — 이상이면 +1, 정상이면 0으로 리셋
         int hrCount;
-        if (isAbnormal(vitalDto.heartRate(), baseline, true)) {
+        if (isAbnormal(vitalDto.heartRate(), baseline, true, conditions)) {
             hrCount = heartConsecutiveMap.merge(userId, 1, Integer::sum);
         } else {
             heartConsecutiveMap.put(userId, 0);
             hrCount = 0;
         }
         int brCount;
-        if (isAbnormal(vitalDto.breathRate(), baseline, false)) {
+        if (isAbnormal(vitalDto.breathRate(), baseline, false, conditions)) {
             brCount = breathConsecutiveMap.merge(userId, 1, Integer::sum);
         } else {
             breathConsecutiveMap.put(userId, 0);
@@ -324,8 +333,13 @@ public class EmergencyEventService {
         return baseline;
     }
 
-    // 이상 여부 판단 — baseline null이면 고령자 표준 임계값, 있으면 개인 가중평균 ±15%
-    private boolean isAbnormal(int value, int[] baseline, boolean isHeart) {
+    // 이상 여부 판단 — 질환 등록 시 질환별 임계값 우선 적용, 없으면 기존 가중평균 ±15% 로직
+    private boolean isAbnormal(int value, int[] baseline, boolean isHeart, List<ConditionType> conditions) {
+        if (!conditions.isEmpty()) {
+            return isAbnormalByCondition(value, baseline, isHeart, conditions);
+        }
+
+        // 질환 없음 — 기존 로직 유지
         if (baseline == null) {
             return isHeart
                 ? (value < ELDERLY_HR_WARN_LOW || value > ELDERLY_HR_WARN_HIGH)
@@ -334,6 +348,67 @@ public class EmergencyEventService {
         int baselineValue = isHeart ? baseline[0] : baseline[1];
         return value < baselineValue * (1 - WARNING_RATIO)
             || value > baselineValue * (1 + WARNING_RATIO);
+    }
+
+    // 질환별 임계값 이상 판정
+    // requireBoth=false(즉시 위험 질환: 패혈증·심근경색·뇌졸중): 임계값 초과만으로 이상 판정
+    // requireBoth=true(중간 위험 질환): 임계값 초과 AND 개인 기준선 ±15% 초과 둘 다 충족해야 이상
+    // baseline null(데이터 부족)이면 모든 질환에서 임계값만으로 판정
+    private boolean isAbnormalByCondition(int value, int[] baseline, boolean isHeart,
+        List<ConditionType> conditions) {
+
+        // Step 1 — 질환 임계값 초과 여부
+        boolean exceedsConditionThreshold = checkConditionThreshold(value, baseline, isHeart, conditions);
+
+        // Step 2 — 개인 기준선 ±15% 초과 여부
+        boolean exceedsBaseline = false;
+        if (baseline != null) {
+            int base = isHeart ? baseline[0] : baseline[1];
+            exceedsBaseline = value < base * (1 - WARNING_RATIO)
+                           || value > base * (1 + WARNING_RATIO);
+        }
+
+        // 즉시 위험 질환(requireBoth=false)이 하나라도 있으면 임계값만으로 판정
+        boolean hasImmediateDanger = conditions.stream().anyMatch(c -> !c.requireBoth);
+        if (hasImmediateDanger) {
+            return exceedsConditionThreshold;
+        }
+
+        // 모두 중간 위험 질환(requireBoth=true)이면 둘 다 초과해야 이상
+        return baseline == null
+            ? exceedsConditionThreshold
+            : exceedsConditionThreshold && exceedsBaseline;
+    }
+
+    // 질환별 절대 임계값 초과 여부 확인 — 복수 질환 선택 시 가장 민감한 기준 적용
+    private boolean checkConditionThreshold(int value, int[] baseline, boolean isHeart,
+        List<ConditionType> conditions) {
+
+        if (isHeart) {
+            int warnHigh = conditions.stream()
+                .filter(c -> c.hrWarnHigh != null)
+                .mapToInt(c -> c.hrWarnHigh)
+                .min().orElse(ELDERLY_HR_WARN_HIGH);
+            int warnLow = conditions.stream()
+                .filter(c -> c.hrWarnLow != null)
+                .mapToInt(c -> c.hrWarnLow)
+                .max().orElse(ELDERLY_HR_WARN_LOW);
+
+            // COPD는 베이스라인 +15% 초과 여부도 확인
+            boolean copdAbnormal = false;
+            if (conditions.contains(ConditionType.COPD) && baseline != null) {
+                copdAbnormal = value > baseline[0] * 1.15;
+            }
+
+            return value >= warnHigh || value <= warnLow || copdAbnormal;
+        } else {
+            int warnHigh = conditions.stream()
+                .filter(c -> c.brWarnHigh != null)
+                .mapToInt(c -> c.brWarnHigh)
+                .min().orElse(ELDERLY_BR_WARN_HIGH);
+
+            return value >= warnHigh;
+        }
     }
 
     // 이벤트 발생 시 활성화된 모든 보호자에게 Notification 저장 + FCM 푸시 전송

--- a/src/main/java/com/ikongserver/service/UserConditionService.java
+++ b/src/main/java/com/ikongserver/service/UserConditionService.java
@@ -1,0 +1,67 @@
+package com.ikongserver.service;
+
+import com.ikongserver.dto.UserConditionDto.ConditionsResponse;
+import com.ikongserver.dto.UserConditionDto.UpdateConditionsRequest;
+import com.ikongserver.entity.ConditionType;
+import com.ikongserver.entity.UserCondition;
+import com.ikongserver.entity.Users;
+import com.ikongserver.repository.UserConditionRepository;
+import com.ikongserver.repository.UsersRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserConditionService {
+
+    private final UserConditionRepository userConditionRepository;
+    private final UsersRepository usersRepository;
+
+    // 현재 등록된 질환 목록 조회
+    @Transactional(readOnly = true)
+    public ConditionsResponse getConditions(Long userId) {
+        Users user = usersRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        List<ConditionType> conditions = userConditionRepository.findByUser(user).stream()
+            .map(UserCondition::getConditionType)
+            .toList();
+
+        return new ConditionsResponse(conditions);
+    }
+
+    // 질환 목록 전체 교체 — 기존 목록 삭제 후 새 목록으로 저장
+    // conditions가 빈 리스트이면 전체 삭제 (질환 없음 상태로 복귀)
+    @Transactional
+    public ConditionsResponse updateConditions(Long userId, UpdateConditionsRequest request) {
+        Users user = usersRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        userConditionRepository.deleteByUser(user);
+
+        List<ConditionType> result = List.of();
+        if (request.conditions() != null && !request.conditions().isEmpty()) {
+            List<UserCondition> newConditions = request.conditions().stream()
+                .distinct()
+                .map(type -> UserCondition.builder().user(user).conditionType(type).build())
+                .toList();
+            userConditionRepository.saveAll(newConditions);
+            result = request.conditions().stream().distinct().toList();
+        }
+
+        return new ConditionsResponse(result);
+    }
+
+    // userId로 등록된 ConditionType 목록 반환 — EmergencyEventService에서 임계값 계산 시 사용
+    @Transactional(readOnly = true)
+    public List<ConditionType> getConditionTypes(Long userId) {
+        Users user = usersRepository.findById(userId)
+            .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        return userConditionRepository.findByUser(user).stream()
+            .map(UserCondition::getConditionType)
+            .toList();
+    }
+}


### PR DESCRIPTION
## 작업 내용

**질병 등록/관리 API**
- 7개 질환 선택 가능: 심근경색, 심부전, 폐렴, 뇌졸중, COPD, 패혈증, 부정맥
- 질환 등록/수정/삭제 API (PUT /api/users/conditions)
- 질환 조회 API (GET /api/users/conditions)
- 복수 선택 가능, 빈 리스트 전송 시 전체 삭제

**알림 판정 로직 — OR 조건, AND 조건 분리**

질환의 위험도에 따라 이상 판정 조건을 두 가지로 분리하였습니다.

OR 조건 (즉시 위험 질환) — 질병 임계값만 초과해도 즉시 알림
| 질환 | 심박 경고 기준 | 호흡 경고 기준 |
|------|-------------|-------------|
| 패혈증 | ≥ 90bpm | ≥ 22회/분 |
| 심근경색 | ≥ 100bpm | ≥ 20회/분 |
| 뇌졸중 | ≥ 110bpm 또는 ≤ 45bpm | ≥ 20회/분 |

적용 이유: 패혈증·심근경색·뇌졸중은 골든타임이 짧아 초기 감지가 중요합니다.
개인 기준선 조건을 추가하면 기준선 편차가 작을 때 실제 위험을 놓칠 수 있습니다.
예) 패혈증 환자 기준선 88bpm → 심박 92bpm 수신 시,
    임계값(≥90) 초과 ✅ but 기준선 대비 4.5% 상승(15% 미만) ❌ → AND이면 알림 미발송

AND 조건 (중간 위험 질환) — 질병 임계값 초과 AND 개인 기준선 ±15% 초과 둘 다 충족해야 알림
| 질환 | 심박 경고 기준 | 호흡 경고 기준 |
|------|-------------|-------------|
| 심부전 | ≥ 90bpm 또는 ≤ 50bpm | ≥ 20회/분 |
| 폐렴 | ≥ 90bpm | ≥ 22회/분 |
| COPD | 기준선 +15% | ≥ 20회/분 |
| 부정맥 | ≥ 130bpm 또는 ≤ 45bpm | ≥ 20회/분 |

적용 이유: 만성 질환 환자는 평소에도 임계값 근처에서 생활하는 경우가 많습니다.
임계값만으로 판정하면 오탐이 빈번하므로 개인 기준선 이탈도 함께 확인합니다.
예) 심부전 환자 평소 심박 92bpm → 심박 93bpm 수신 시,
    임계값(≥90) 초과 ✅ but 기준선 대비 1% 상승 ❌ → AND이므로 정상 처리 (오탐 방지)

공통 조건
- 위 이상 판정이 30초 연속 지속되어야 알림 발송
- 심박·호흡 동시 이상 → VITAL_ISSUE / CRITICAL
- 한쪽만 이상 → HEART_ISSUE 또는 BREATH_ISSUE / WARNING
- 복수 질환 선택 시 가장 민감한 임계값 기준 적용
- 개인 데이터 부족(10건 미만) 시 모든 질환에서 임계값만으로 판정
- 질환 미선택 시 기존 개인 가중평균 기준선 ±15% 로직 유지

## 테스트
- Thunder Client로 질환 등록/수정/삭제/조회 API 확인
- Supabase user_condition 테이블 데이터 저장 확인