### PR TITLE
feat:질병 맞춤 알림 OR/AND 조건 로직 개선

### DIFF
--- a/src/main/java/com/ikongserver/service/EmergencyEventService.java
+++ b/src/main/java/com/ikongserver/service/EmergencyEventService.java
@@ -333,21 +333,39 @@ public class EmergencyEventService {
         return baseline;
     }
 
-    // 이상 여부 판단 — 질환 등록 시 질환별 임계값 우선 적용, 없으면 기존 가중평균 ±15% 로직
+    // 이상 여부 판단
+    // 질환 미등록: 기존 기준선 로직만 적용
+    // OR 질환(즉시 위험): 기존 기준선 이상 OR 질환 임계값 초과 — 하나라도 이상이면 알림
+    // AND 질환(중간 위험): 기존 기준선 이상 AND 질환 임계값 초과 — 둘 다 이상이어야 알림
     private boolean isAbnormal(int value, int[] baseline, boolean isHeart, List<ConditionType> conditions) {
-        if (!conditions.isEmpty()) {
-            return isAbnormalByCondition(value, baseline, isHeart, conditions);
-        }
-
-        // 질환 없음 — 기존 로직 유지
+        // 기존 기준선 로직
+        boolean baselineAbnormal;
         if (baseline == null) {
-            return isHeart
+            baselineAbnormal = isHeart
                 ? (value < ELDERLY_HR_WARN_LOW || value > ELDERLY_HR_WARN_HIGH)
                 : (value < ELDERLY_BR_WARN_LOW || value > ELDERLY_BR_WARN_HIGH);
+        } else {
+            int base = isHeart ? baseline[0] : baseline[1];
+            baselineAbnormal = value < base * (1 - WARNING_RATIO)
+                            || value > base * (1 + WARNING_RATIO);
         }
-        int baselineValue = isHeart ? baseline[0] : baseline[1];
-        return value < baselineValue * (1 - WARNING_RATIO)
-            || value > baselineValue * (1 + WARNING_RATIO);
+
+        // 질환 미등록 — 기존 로직만
+        if (conditions.isEmpty()) {
+            return baselineAbnormal;
+        }
+
+        // 질환 임계값 초과 여부
+        boolean conditionAbnormal = checkConditionThreshold(value, baseline, isHeart, conditions);
+
+        // OR 질환(즉시 위험)이 하나라도 있으면 → 둘 중 하나라도 이상이면 알림
+        boolean hasOrCondition = conditions.stream().anyMatch(c -> !c.requireBoth);
+        if (hasOrCondition) {
+            return baselineAbnormal || conditionAbnormal;
+        }
+
+        // AND 질환(중간 위험)만 있으면 → 둘 다 이상이어야 알림
+        return baselineAbnormal && conditionAbnormal;
     }
 
     // 질환별 임계값 이상 판정


### PR DESCRIPTION
## 작업 내용

**질병 등록/관리 API**
- 7개 질환 선택 가능: 심근경색, 심부전, 폐렴, 뇌졸중, COPD, 패혈증, 부정맥
- 질환 등록/수정/삭제 API (PUT /api/users/conditions)
- 질환 조회 API (GET /api/users/conditions)
- 복수 선택 가능, 빈 리스트 전송 시 전체 삭제

**알림 판정 로직 — OR/AND 조건 분리**

OR 질환 (패혈증·심근경색·뇌졸중) — 즉시 위험 질환
- 기존 기준선 ±15% 이상 OR 질병 임계값 초과
- 둘 중 하나라도 이상이면 30초 지속 시 알림 발송
- 이유: 골든타임이 짧아 놓치면 안 되는 질환

AND 질환 (심부전·폐렴·COPD·부정맥) — 만성 질환
- 기존 기준선 ±15% 이상 AND 질병 임계값 초과
- 둘 다 이상이어야 30초 지속 시 알림 발송
- 이유: 만성 질환자는 평소 임계값 근처 생활 → 오탐 방지 필요

질환별 임계값
| 질환 | 조건 | 심박 기준 | 호흡 기준 |
|------|------|---------|---------|
| 패혈증 | OR | ≥ 90bpm | ≥ 22회 |
| 심근경색 | OR | ≥ 100bpm | ≥ 20회 |
| 뇌졸중 | OR | ≥ 110 또는 ≤ 45bpm | ≥ 20회 |
| 심부전 | AND | ≥ 90 또는 ≤ 50bpm | ≥ 20회 |
| 폐렴 | AND | ≥ 90bpm | ≥ 22회 |
| COPD | AND | 기준선 +15% | ≥ 20회 |
| 부정맥 | AND | ≥ 130 또는 ≤ 45bpm | ≥ 20회 |